### PR TITLE
Update cicd-deploy-amplify-branch.yaml

### DIFF
--- a/.github/workflows/cicd-deploy-amplify-branch.yaml
+++ b/.github/workflows/cicd-deploy-amplify-branch.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ASSUME_ROLE_NAME }}
           role-session-name: deployInfra
           aws-region: ${{ needs.metadata.outputs.aws_region }}
       - name:  Terraform Plan


### PR DESCRIPTION
GitHub secrets for Terraform must be granular to avoid appearing in logs. For example, use arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ASSUME_ROLE_NAME }}. It has been proven that if a role ARN is defined as AWS_ROLE_ARN, details such as the account number are not redacted from the output and are visible in plain text. While this information may not be considered sensitive on its own, it could contribute to a vector attack and therefore be used to exploit the service.