### PR TITLE
CCM-7718: remove submit go-back button

### DIFF
--- a/src/__tests__/components/forms/SubmitTemplate/__snapshots__/SubmitTemplate.test.tsx.snap
+++ b/src/__tests__/components/forms/SubmitTemplate/__snapshots__/SubmitTemplate.test.tsx.snap
@@ -92,16 +92,6 @@ exports[`SubmitTemplate component should render 1`] = `
           type="hidden"
           value="template-id"
         />
-        <a
-          aria-disabled="false"
-          class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-right-3"
-          draggable="false"
-          href="/templates/example/template-id"
-          id="go-back-button"
-          role="button"
-        >
-          Go back
-        </a>
         <button
           aria-disabled="false"
           class="nhsuk-button"

--- a/src/__tests__/components/forms/SubmitTemplate/__snapshots__/SubmitTemplate.test.tsx.snap
+++ b/src/__tests__/components/forms/SubmitTemplate/__snapshots__/SubmitTemplate.test.tsx.snap
@@ -6,28 +6,6 @@ exports[`SubmitTemplate component should render 1`] = `
     class="nhsuk-grid-row"
   >
     <div
-      class="nhsuk-back-link"
-    >
-      <a
-        class="nhsuk-back-link__link nhsuk-u-margin-bottom-7 nhsuk-u-margin-left-3"
-        href="/templates/example/template-id"
-      >
-        <svg
-          aria-hidden="true"
-          class="nhsuk-icon nhsuk-icon__chevron-left"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"
-          />
-        </svg>
-        Go back
-      </a>
-    </div>
-    <div
       class="nhsuk-grid-column-two-thirds"
     >
       <h1>
@@ -92,6 +70,16 @@ exports[`SubmitTemplate component should render 1`] = `
           type="hidden"
           value="template-id"
         />
+        <a
+          aria-disabled="false"
+          class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-right-3"
+          draggable="false"
+          href="/templates/example/template-id"
+          id="go-back-button"
+          role="button"
+        >
+          Go back
+        </a>
         <button
           aria-disabled="false"
           class="nhsuk-button"

--- a/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
+++ b/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
@@ -23,7 +23,6 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
     submitChecklistIntroduction,
     submitChecklistItems,
     submitChecklistParagraphs,
-    goBackButtonText,
     buttonText,
   } = submitTemplateContent;
 
@@ -60,14 +59,6 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
           action={submitTemplate.bind(null, submitPath)}
         >
           <input type='hidden' name='templateId' value={templateId} readOnly />
-          <Button
-            secondary
-            id='go-back-button'
-            className='nhsuk-u-margin-right-3'
-            href={`${getBasePath()}/${goBackPath}/${templateId}`}
-          >
-            {goBackButtonText}
-          </Button>
           <Button id='submit-template-button'>{buttonText}</Button>
         </NHSNotifyFormWrapper>
       </div>

--- a/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
+++ b/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FC } from 'react';
-import { WarningCallout, Button, BackLink } from 'nhsuk-react-components';
+import { WarningCallout, Button } from 'nhsuk-react-components';
 import { SubmitTemplatePageComponentProps } from '@utils/types';
 import { submitTemplateContent } from '@content/content';
 import { NHSNotifyFormWrapper } from '@molecules/NHSNotifyFormWrapper/NHSNotifyFormWrapper';
@@ -15,7 +15,6 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
   submitPath,
 }) => {
   const {
-    backLinkText,
     pageHeading,
     warningCalloutLabel,
     warningCalloutText,
@@ -23,17 +22,12 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
     submitChecklistIntroduction,
     submitChecklistItems,
     submitChecklistParagraphs,
+    goBackButtonText,
     buttonText,
   } = submitTemplateContent;
 
   return (
     <div className='nhsuk-grid-row'>
-      <BackLink
-        href={`${getBasePath()}/${goBackPath}/${templateId}`}
-        className='nhsuk-u-margin-bottom-7 nhsuk-u-margin-left-3'
-      >
-        {backLinkText}
-      </BackLink>
       <div className='nhsuk-grid-column-two-thirds'>
         <h1>
           {pageHeading} {`'${templateName}'`}
@@ -59,6 +53,14 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
           action={submitTemplate.bind(null, submitPath)}
         >
           <input type='hidden' name='templateId' value={templateId} readOnly />
+          <Button
+            secondary
+            id='go-back-button'
+            className='nhsuk-u-margin-right-3'
+            href={`${getBasePath()}/${goBackPath}/${templateId}`}
+          >
+            {goBackButtonText}
+          </Button>
           <Button id='submit-template-button'>{buttonText}</Button>
         </NHSNotifyFormWrapper>
       </div>

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -309,7 +309,6 @@ export const submitTemplateContent = {
     'When you submit a template, it will be used by NHS Notify to set up the messages you want to send.',
     'If you want to change a submitted template, you must create and submit a new template to replace it.',
   ],
-  goBackButtonText: 'Go back',
   buttonText: 'Submit template',
 };
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -293,7 +293,6 @@ const error404PageContent = {
 };
 
 export const submitTemplateContent = {
-  backLinkText: 'Go back',
   pageHeading: 'Submit',
   warningCalloutLabel: 'Important',
   warningCalloutText:
@@ -309,6 +308,7 @@ export const submitTemplateContent = {
     'When you submit a template, it will be used by NHS Notify to set up the messages you want to send.',
     'If you want to change a submitted template, you must create and submit a new template to replace it.',
   ],
+  goBackButtonText: 'Go back',
   buttonText: 'Submit template',
 };
 

--- a/tests/test-team/pages/template-mgmt-submit-page.ts
+++ b/tests/test-team/pages/template-mgmt-submit-page.ts
@@ -4,6 +4,8 @@ import { TemplateMgmtBasePage } from './template-mgmt-base-page';
 export class TemplateMgmtSubmitPage extends TemplateMgmtBasePage {
   public readonly submitButton: Locator;
 
+  public readonly goBackButton: Locator;
+
   constructor(
     page: Page,
     private readonly channelIdentifier: string
@@ -11,6 +13,9 @@ export class TemplateMgmtSubmitPage extends TemplateMgmtBasePage {
     super(page);
     this.submitButton = page
       .locator('[id="submit-template-button"]')
+      .and(page.getByRole('button'));
+    this.goBackButton = page
+      .locator('[id="go-back-button"]')
       .and(page.getByRole('button'));
   }
 
@@ -22,5 +27,9 @@ export class TemplateMgmtSubmitPage extends TemplateMgmtBasePage {
 
   async clickSubmitTemplateButton() {
     await this.submitButton.click();
+  }
+
+  async clickGoBackButton() {
+    await this.goBackButton.click();
   }
 }

--- a/tests/test-team/template-mgmt-component-tests/template-mgmt-common.steps.ts
+++ b/tests/test-team/template-mgmt-component-tests/template-mgmt-common.steps.ts
@@ -53,7 +53,7 @@ export function assertGoBackLink({
   baseURL,
   expectedUrl,
 }: CommonStepsProps & { expectedUrl: string }) {
-  return test.step('when user clicks "Go back", then user is redirect to previous page', async () => {
+  return test.step('when user clicks "Go back", then user is redirected to previous page', async () => {
     await page.loadPage(id);
 
     await page.goBackLink.click();

--- a/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-common.steps.ts
+++ b/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-common.steps.ts
@@ -13,7 +13,7 @@ export function assertGoBackButton({
   baseURL,
   expectedUrl,
 }: CommonStepsProps & { expectedUrl: string }) {
-  return test.step('when user clicks "Go back" button, then user is redirect to previous page', async () => {
+  return test.step('when user clicks "Go back" button, then user is redirected to previous page', async () => {
     await page.loadPage(id);
 
     await page.clickGoBackButton();

--- a/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-common.steps.ts
+++ b/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-common.steps.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { TemplateMgmtSubmitPage } from '../pages/template-mgmt-submit-page';
+
+type CommonStepsProps = {
+  page: TemplateMgmtSubmitPage;
+  id: string;
+  baseURL?: string;
+};
+
+export function assertGoBackButton({
+  page,
+  id,
+  baseURL,
+  expectedUrl,
+}: CommonStepsProps & { expectedUrl: string }) {
+  return test.step('when user clicks "Go back" button, then user is redirect to previous page', async () => {
+    await page.loadPage(id);
+
+    await page.clickGoBackButton();
+
+    await expect(page.page).toHaveURL(`${baseURL}/${expectedUrl}`);
+  });
+}

--- a/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-page.component.ts
+++ b/tests/test-team/template-mgmt-component-tests/template-mgmt-submit-page.component.ts
@@ -2,14 +2,14 @@ import { test, expect } from '@playwright/test';
 import { TemplateStorageHelper } from '../helpers/template-storage-helper';
 import { TemplateMgmtSubmitPage } from '../pages/template-mgmt-submit-page';
 import { TemplateFactory } from '../helpers/template-factory';
+import { Template, TemplateType, TemplateStatus } from '../helpers/types';
 import {
   assertFooterLinks,
-  assertGoBackLink,
   assertLoginLink,
   assertNotifyBannerLink,
   assertSkipToMainContent,
 } from './template-mgmt-common.steps';
-import { Template, TemplateType, TemplateStatus } from '../helpers/types';
+import { assertGoBackButton } from './template-mgmt-submit-common.steps';
 
 const emailFields = {
   name: 'test-template-name',
@@ -157,7 +157,7 @@ test.describe('Submit template Page', () => {
         await assertNotifyBannerLink(props);
         await assertLoginLink(props);
         await assertFooterLinks(props);
-        await assertGoBackLink({
+        await assertGoBackButton({
           ...props,
           expectedUrl: `templates/preview-${channelIdentifier}-template/${templates[channelIdentifier].valid.id}`,
         });


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Remove the top 'Go back' link from submit pages.

## Context

User research suggests the button at the bottom is best. No need for both.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## Test Evidence

![image](https://github.com/user-attachments/assets/06fbe62f-266e-4916-9fc8-42f0d0b2907d)

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
