### PR TITLE
CCM-7357: (templates) Disable automatic build for main branch and provide TF output for post-deployment hook

### DIFF
--- a/infrastructure/terraform/components/app/amplify_domain_association.tf
+++ b/infrastructure/terraform/components/app/amplify_domain_association.tf
@@ -4,13 +4,13 @@
 #   enable_auto_sub_domain = true
 
 #   sub_domain {
-#     branch_name = module.amplify_branch.name
+#     branch_name = var.branch_name
 #     prefix      = ""
 #   }
 
 #   sub_domain {
-#     branch_name = module.amplify_branch.name
-#     prefix      = "main"
+#     branch_name = var.branch_name
+#     prefix      = var.url_prefix
 #   }
 # }
 
@@ -19,13 +19,14 @@
 resource "null_resource" "amplify_domain_association" {
   triggers = {
     amplify_app_id      = aws_amplify_app.main.id
-    amplify_branch_name = module.amplify_branch.name
+    amplify_branch_name = var.branch_name
+    amplify_url_prefix  = var.url_prefix
     amplify_domain_name = local.root_domain_name
   }
 
   provisioner "local-exec" {
     when    = create
-    command = "aws amplify create-domain-association --app-id ${self.triggers.amplify_app_id} --domain-name ${self.triggers.amplify_domain_name} --sub-domain-settings prefix=\"\",branchName=\"${self.triggers.amplify_branch_name}\" prefix=\"${self.triggers.amplify_branch_name}\",branchName=\"${self.triggers.amplify_branch_name}\" --enable-auto-sub-domain --auto-sub-domain-creation-patterns \"*,*/*,pr*\""
+    command = "aws amplify create-domain-association --app-id ${self.triggers.amplify_app_id} --domain-name ${self.triggers.amplify_domain_name} --sub-domain-settings prefix=\"\",branchName=\"${self.triggers.amplify_branch_name}\" prefix=\"${self.triggers.amplify_url_prefix}\",branchName=\"${self.triggers.amplify_branch_name}\" --enable-auto-sub-domain --auto-sub-domain-creation-patterns \"*,*/*,pr*\""
   }
 
   provisioner "local-exec" {

--- a/infrastructure/terraform/components/app/module_amplify_branch.tf
+++ b/infrastructure/terraform/components/app/module_amplify_branch.tf
@@ -2,7 +2,7 @@ module "amplify_branch" {
   source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/amp_branch?ref=v1.0.0"
 
   name              = "main"
-  display_name      = "main"
+  display_name      = var.url_prefix
   aws_account_id    = var.aws_account_id
   component         = var.component
   environment       = var.environment
@@ -13,7 +13,7 @@ module "amplify_branch" {
   amplify_app_id    = aws_amplify_app.main.id
   branch            = var.branch_name
   stage             = "PRODUCTION"
-  enable_auto_build = true
+  enable_auto_build = false
 
   environment_variables = {
     NOTIFY_SUBDOMAIN      = var.environment

--- a/infrastructure/terraform/components/app/outputs.tf
+++ b/infrastructure/terraform/components/app/outputs.tf
@@ -2,6 +2,20 @@ output "amplify" {
   value = {
     id          = aws_amplify_app.main.id
     domain_name = local.root_domain_name
+    branch_name = var.branch_name
+  }
+}
+
+output "deployment" {
+  description = "Deployment details used for post-deployment scripts"
+  value = {
+    aws_region     = var.region
+    aws_account_id = var.aws_account_id
+    project        = var.project
+    environment    = var.environment
+    group          = var.group
+    component      = var.component
+    commit_id      = var.commit_id
   }
 }
 

--- a/infrastructure/terraform/components/app/variables.tf
+++ b/infrastructure/terraform/components/app/variables.tf
@@ -99,6 +99,18 @@ variable "branch_name" {
   default     = "main"
 }
 
+variable "url_prefix" {
+  type        = string
+  description = "The url prefix to use for the deployed branch"
+  default     = "main"
+}
+
+variable "commit_id" {
+  type        = string
+  description = "The commit to deploy. Must be in the tree for branch_name"
+  default     = "HEAD"
+}
+
 variable "disable_content" {
   type        = string
   description = "Value for turning switching disable conten true/false"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

* This disables autobuild for the main branch deployed as part of the 'app' component.
* Amplify branch deployment can be manually triggered or triggered from the reusable workflow in the internal repo

## Context

<!-- Why is this change required? What problem does it solve? -->

* Amplify currently auto-builds the main branch of the repository as soon as it is committed
* This commit will disable the auto-build behaviour for the main branch only
* The changes in the internal deployment repo allow a new deployment workflow to be created to trigger a deployment to Amplify after the other GitHub workflow stages have completed successfully (i.e. QA and terraform deployment)

## Notes

* Commit ID and description need to be passed to terraform from the CD workflow in nhs-notify-internal
* The commit must exist in the tree of the branch associated with Amplify. This means that if you are triggering a build on the main branch, the commit (or tag) being released must also be in the history of the main branch.
* If you do want to deploy a testing branch that isn't merged to main yet, then you need to override the branch_name variable for the pipeline, which will destroy and recreate the 'main' application branch (not advisable for prod as it may lead to downtime)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
