### PR TITLE
CCM-7825: remove lambdas folder before amplify deployment

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -12,6 +12,7 @@ frontend:
   phases:
     build:
       commands:
+        - rm -rf lambdas
         - npm run build
   artifacts:
     baseDirectory: .next


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Amplify is building the lambda projects, but `npm ci` does not install their packages.  
The lambdas should not be part of the Amplify deployment so the folder is deleted just before the build command. A follow up ticket will be created to restructure the repo so Next is in its own subfolder.

## Context

Amplify deployments are currently broken.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## Test evidence

Successful deployment:

![image](https://github.com/user-attachments/assets/826c39f8-d969-48fa-9b44-8cec186a905f)

Site working as expected:

![image](https://github.com/user-attachments/assets/9f79e708-dc5f-4f57-a7d1-e96964820ee1)

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
