### PR TITLE
CCM-6413 enable auto builds

### DIFF
--- a/infrastructure/terraform/components/app/null_resource_initial_amplify_branch_build.tf
+++ b/infrastructure/terraform/components/app/null_resource_initial_amplify_branch_build.tf
@@ -1,0 +1,13 @@
+resource "null_resource" "initial_amplify_branch_build" {
+  # Trigger initial build when the branch is creates. Subsequent commits to the branch would cause builds anyway
+  triggers = {
+    csi                 = local.csi
+    amplify_app_id      = aws_amplify_app.main.id
+    amplify_branch_name = module.amplify_branch.name
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "aws amplify start-job --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name} --job-type 'RELEASE'"
+  }
+}

--- a/infrastructure/terraform/components/app/null_resource_initial_amplify_branch_build.tf
+++ b/infrastructure/terraform/components/app/null_resource_initial_amplify_branch_build.tf
@@ -7,7 +7,6 @@ resource "null_resource" "initial_amplify_branch_build" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
     command = "aws amplify start-job --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name} --job-type 'RELEASE'"
   }
 }

--- a/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
+++ b/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
@@ -1,0 +1,13 @@
+resource "null_resource" "initial_amplify_branch_build" {
+  # Trigger initial build when the branch is creates. Subsequent commits to the branch would cause builds anyway
+  triggers = {
+    csi                 = local.csi
+    amplify_app_id      = local.app.amplify["id"]
+    amplify_branch_name = module.amplify_branch.name
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "aws amplify start-deployment --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name}"
+  }
+}

--- a/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
+++ b/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
@@ -8,6 +8,6 @@ resource "null_resource" "initial_amplify_branch_build" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "aws amplify start-deployment --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name}"
+    command = "aws amplify start-job --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name} --job-type 'RELEASE'"
   }
 }

--- a/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
+++ b/infrastructure/terraform/components/branch/null_resource_initial_amplify_branch_build.tf
@@ -7,7 +7,6 @@ resource "null_resource" "initial_amplify_branch_build" {
   }
 
   provisioner "local-exec" {
-    when    = destroy
     command = "aws amplify start-job --app-id ${self.triggers.amplify_app_id} --branch-name ${self.triggers.amplify_branch_name} --job-type 'RELEASE'"
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Forces newly created branches to automatically build when they are created in Amplify. Subsequent pushes to a PR cause this to happen anyway, but not having that first one when a new branch gets deployed is quite annoying.

https://eu-west-2.console.aws.amazon.com/amplify/apps/d1cnvxdzxtz999/branches/CCM-6413_enableAutoBuilds/deployments# to see it working
![image](https://github.com/user-attachments/assets/6d74ba5e-889e-44d6-a217-e76352a6fc0b)


<!-- Describe your changes in detail. -->

## Context
Newly deployed environments and PRs are not building until a secondary commit occurs after the creation of the environment/branch
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
