### PR TITLE
CCM-5662: Override ses domain

### DIFF
--- a/infrastructure/terraform/components/app/locals.tf
+++ b/infrastructure/terraform/components/app/locals.tf
@@ -1,3 +1,4 @@
 locals {
   root_domain_name = "${var.environment}.${local.acct.dns_zone["name"]}"
+  ses_domain_name = var.override_ses_domain_name == "NA" ? local.root_domain_name : var.override_ses_domain_name
 }

--- a/infrastructure/terraform/components/app/locals.tf
+++ b/infrastructure/terraform/components/app/locals.tf
@@ -1,4 +1,4 @@
 locals {
   root_domain_name = "${var.environment}.${local.acct.dns_zone["name"]}"
-  ses_domain_name = var.override_ses_domain_name == "NA" ? local.root_domain_name : var.override_ses_domain_name
+  ses_domain_name  = var.override_ses_domain_name == "NA" ? local.root_domain_name : var.override_ses_domain_name
 }

--- a/infrastructure/terraform/components/app/module_backend_api.tf
+++ b/infrastructure/terraform/components/app/module_backend_api.tf
@@ -8,7 +8,7 @@ module "backend_api" {
   group                 = var.group
   csi                   = local.csi
   log_retention_in_days = var.log_retention_in_days
-  email_domain_name     = local.root_domain_name
+  email_domain_name     = local.ses_domain_name
 
   cognito_config        = jsondecode(data.aws_ssm_parameter.cognito_config.value)
 }

--- a/infrastructure/terraform/components/app/module_backend_api.tf
+++ b/infrastructure/terraform/components/app/module_backend_api.tf
@@ -10,5 +10,5 @@ module "backend_api" {
   log_retention_in_days = var.log_retention_in_days
   email_domain_name     = local.ses_domain_name
 
-  cognito_config        = jsondecode(data.aws_ssm_parameter.cognito_config.value)
+  cognito_config = jsondecode(data.aws_ssm_parameter.cognito_config.value)
 }

--- a/infrastructure/terraform/components/app/route53_record_ses_dkim_validation.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_dkim_validation.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ses_dkim_validation" {
-  count = 3
+  count = var.override_ses_domain_name == "NA" ? 3 : 0
 
   zone_id = local.acct.dns_zone["id"]
   name    = "${aws_ses_domain_dkim.main.dkim_tokens[count.index]}._domainkey"

--- a/infrastructure/terraform/components/app/route53_record_ses_dmarc.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_dmarc.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ses_dmarc" {
-  count = var.override_ses_domain_name == "NA" ? 1 : 0
+  count   = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = "_dmarc.${aws_ses_domain_identity.main.id}"
   type    = "TXT"

--- a/infrastructure/terraform/components/app/route53_record_ses_dmarc.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_dmarc.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "ses_dmarc" {
+  count = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = "_dmarc.${aws_ses_domain_identity.main.id}"
   type    = "TXT"

--- a/infrastructure/terraform/components/app/route53_record_ses_mail_from_mx.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_mail_from_mx.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ses_mail_from_mx" {
-  count = var.override_ses_domain_name == "NA" ? 1 : 0
+  count   = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "MX"

--- a/infrastructure/terraform/components/app/route53_record_ses_mail_from_mx.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_mail_from_mx.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "ses_mail_from_mx" {
+  count = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "MX"

--- a/infrastructure/terraform/components/app/route53_record_ses_mail_from_txt.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_mail_from_txt.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ses_mail_from_txt" {
-  count = var.override_ses_domain_name == "NA" ? 1 : 0
+  count   = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"

--- a/infrastructure/terraform/components/app/route53_record_ses_mail_from_txt.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_mail_from_txt.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "ses_mail_from_txt" {
+  count = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"

--- a/infrastructure/terraform/components/app/route53_record_ses_validation.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_validation.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ses_validation" {
-  count = var.override_ses_domain_name == "NA" ? 1 : 0
+  count   = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = "_amazonses.${aws_ses_domain_identity.main.id}"
   type    = "TXT"

--- a/infrastructure/terraform/components/app/route53_record_ses_validation.tf
+++ b/infrastructure/terraform/components/app/route53_record_ses_validation.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "ses_validation" {
+  count = var.override_ses_domain_name == "NA" ? 1 : 0
   zone_id = local.acct.dns_zone["id"]
   name    = "_amazonses.${aws_ses_domain_identity.main.id}"
   type    = "TXT"

--- a/infrastructure/terraform/components/app/ses_domain_identity.tf
+++ b/infrastructure/terraform/components/app/ses_domain_identity.tf
@@ -1,3 +1,3 @@
 resource "aws_ses_domain_identity" "main" {
-  domain = local.root_domain_name
+  domain = local.ses_domain_name
 }

--- a/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
@@ -5,7 +5,7 @@ resource "aws_ssm_parameter" "amplify_password" {
   description = "The Basic Auth password used for the amplify app. This parameter is sourced from Github Environment variables"
 
   type  = "String"
-  value = var.AMPLIFY_BASIC_AUTH_SECRET != "unset" ?  var.AMPLIFY_BASIC_AUTH_SECRET : random_password.password[0].result
+  value = var.AMPLIFY_BASIC_AUTH_SECRET != "unset" ? var.AMPLIFY_BASIC_AUTH_SECRET : random_password.password[0].result
 }
 
 resource "random_password" "password" {

--- a/infrastructure/terraform/components/app/ssm_parameter_cognito_config.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_cognito_config.tf
@@ -1,3 +1,3 @@
 data "aws_ssm_parameter" "cognito_config" {
-  name        = "/${local.csi}/cognito_config"
+  name = "/${local.csi}/cognito_config"
 }

--- a/infrastructure/terraform/components/app/variables.tf
+++ b/infrastructure/terraform/components/app/variables.tf
@@ -124,3 +124,9 @@ variable "disable_content" {
   description = "Value for turning switching disable conten true/false"
   default     = "false"
 }
+
+variable "override_ses_domain_name" {
+  type        = string
+  description = "Override SES Domain name"
+  default     = "NA"
+}

--- a/infrastructure/terraform/components/branch/module_amplify_branch.tf
+++ b/infrastructure/terraform/components/branch/module_amplify_branch.tf
@@ -18,7 +18,7 @@ module "amplify_branch" {
   enable_auto_build = true
 
   environment_variables = {
-    NOTIFY_SUBDOMAIN              = var.environment
-    NEXT_PUBLIC_BASE_PATH         = "/templates~${local.normalised_branch_name}"
+    NOTIFY_SUBDOMAIN      = var.environment
+    NEXT_PUBLIC_BASE_PATH = "/templates~${local.normalised_branch_name}"
   }
 }

--- a/infrastructure/terraform/components/sandbox/aws_cognito_user_pool_client_sandbox.tf
+++ b/infrastructure/terraform/components/sandbox/aws_cognito_user_pool_client_sandbox.tf
@@ -10,7 +10,7 @@ resource "aws_cognito_user_pool_client" "sandbox" {
 
   access_token_validity  = 15 # 1 minutes
   id_token_validity      = 15 # 1 minutes
-  refresh_token_validity = 1 # 1 hour
+  refresh_token_validity = 1  # 1 hour
 
   token_validity_units {
     access_token  = "minutes"

--- a/infrastructure/terraform/modules/backend-api/dynamodb_table_templates.tf
+++ b/infrastructure/terraform/modules/backend-api/dynamodb_table_templates.tf
@@ -1,31 +1,31 @@
 resource "aws_dynamodb_table" "templates" {
-    name = "${local.csi}-templates"
-    billing_mode = "PAY_PER_REQUEST"
+  name         = "${local.csi}-templates"
+  billing_mode = "PAY_PER_REQUEST"
 
-    hash_key = "owner"
-    range_key = "id"
+  hash_key  = "owner"
+  range_key = "id"
 
-    attribute {
-      name = "owner"
-      type = "S"
-    }
+  attribute {
+    name = "owner"
+    type = "S"
+  }
 
-    attribute {
-        name = "id"
-        type = "S"
-    }
+  attribute {
+    name = "id"
+    type = "S"
+  }
 
-    ttl {
-      attribute_name = "ttl"
-      enabled        = true
-    }
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
 
-    point_in_time_recovery {
-      enabled = true
-    }
+  point_in_time_recovery {
+    enabled = true
+  }
 
-    server_side_encryption {
-        enabled     = true
-        kms_key_arn = aws_kms_key.dynamo.arn
-    }
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.dynamo.arn
+  }
 }

--- a/infrastructure/terraform/modules/backend-api/locals.tf
+++ b/infrastructure/terraform/modules/backend-api/locals.tf
@@ -15,11 +15,11 @@ locals {
   })
 
   backend_lambda_entrypoints = {
-    create_template  = "src/templates/api/create.ts"
-    get_template     = "src/templates/api/get.ts"
-    update_template  = "src/templates/api/update.ts"
-    list_template    = "src/templates/api/list.ts"
-    send_email       = "src/email/handler.ts"
-    template_client  = "src/index.ts"
+    create_template = "src/templates/api/create.ts"
+    get_template    = "src/templates/api/get.ts"
+    update_template = "src/templates/api/update.ts"
+    list_template   = "src/templates/api/list.ts"
+    send_email      = "src/email/handler.ts"
+    template_client = "src/index.ts"
   }
 }

--- a/infrastructure/terraform/modules/backend-api/module_build_template_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_build_template_lambda.tf
@@ -2,7 +2,7 @@ module "build_template_lambda" {
   source = "../typescript-build-zip"
 
   source_code_dir = "${local.lambdas_source_code_dir}/backend-api"
-  entrypoints     = [
+  entrypoints = [
     local.backend_lambda_entrypoints.create_template,
     local.backend_lambda_entrypoints.get_template,
     local.backend_lambda_entrypoints.update_template,
@@ -15,5 +15,5 @@ module "build_template_client" {
   source = "../typescript-build-zip"
 
   source_code_dir = "${local.lambdas_source_code_dir}/backend-client"
-  entrypoints      = [local.backend_lambda_entrypoints.template_client]
+  entrypoints     = [local.backend_lambda_entrypoints.template_client]
 }

--- a/infrastructure/terraform/modules/backend-api/module_create_template_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_create_template_lambda.tf
@@ -1,5 +1,5 @@
 module "create_template_lambda" {
-  depends_on  = [module.build_template_lambda, module.build_template_client]
+  depends_on = [module.build_template_lambda, module.build_template_client]
 
   source      = "../lambda-function"
   description = "Create template API endpoint"

--- a/infrastructure/terraform/modules/backend-api/module_email_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_email_lambda.tf
@@ -1,5 +1,5 @@
 module "email_lambda" {
-  depends_on  = [module.build_template_lambda, module.build_template_client]
+  depends_on = [module.build_template_lambda, module.build_template_client]
 
   source      = "../lambda-function"
   description = "Send an email to the recipient"
@@ -14,7 +14,7 @@ module "email_lambda" {
 
   environment_variables = {
     TEMPLATES_TABLE_NAME = aws_dynamodb_table.templates.name
-    SENDER_EMAIL = "no-reply@${var.email_domain_name}"
+    SENDER_EMAIL         = "no-reply@${var.email_domain_name}"
   }
 
   execution_role_policy_document = data.aws_iam_policy_document.email_lambda.json
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "email_lambda" {
   }
 
   statement {
-    sid  = "AllowSESAccess"
+    sid    = "AllowSESAccess"
     effect = "Allow"
 
     actions = ["ses:SendRawEmail"]

--- a/infrastructure/terraform/modules/backend-api/module_get_template_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_get_template_lambda.tf
@@ -1,5 +1,5 @@
 module "get_template_lambda" {
-  depends_on  = [module.build_template_lambda, module.build_template_client]
+  depends_on = [module.build_template_lambda, module.build_template_client]
 
   source      = "../lambda-function"
   description = "Get template API endpoint"

--- a/infrastructure/terraform/modules/backend-api/module_list_template_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_list_template_lambda.tf
@@ -1,5 +1,5 @@
 module "list_template_lambda" {
-  depends_on  = [module.build_template_lambda, module.build_template_client]
+  depends_on = [module.build_template_lambda, module.build_template_client]
 
   source      = "../lambda-function"
   description = "List template API endpoint"

--- a/infrastructure/terraform/modules/backend-api/module_update_template_lambda.tf
+++ b/infrastructure/terraform/modules/backend-api/module_update_template_lambda.tf
@@ -1,5 +1,5 @@
 module "update_template_lambda" {
-  depends_on  = [module.build_template_lambda, module.build_template_client]
+  depends_on = [module.build_template_lambda, module.build_template_client]
 
   source      = "../lambda-function"
   description = "Update template API endpoint"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Adding functionality to override SES domain especially for Production so that we can use the "notify.nhs.uk" domain there to send out comms

<!-- Describe your changes in detail. -->

## Context

On Production, we would want to send out email communications via a more known domain rather than the default domain we have setup for environments which is of the format "main.templates.prod.nhsnotify.national.nhs.uk" which might not give clients confidence that the email is coming from a known source, so we are adding an override domain functionality to have Production use "notify.nhs.uk" instead

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
