### PR TITLE
CCM-8426 Add ui tests for the create pages

### DIFF
--- a/tests/test-team/pages/email/template-mgmt-edit-email-page.ts
+++ b/tests/test-team/pages/email/template-mgmt-edit-email-page.ts
@@ -2,7 +2,7 @@ import { Locator, Page } from '@playwright/test';
 import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
 
-export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditEmailPage extends TemplateMgmtBasePage {
   public readonly nameInput: Locator;
 
   public readonly subjectLineInput: Locator;
@@ -14,8 +14,6 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
   public readonly personalisationFields: Locator;
 
   public readonly namingYourTemplate: Locator;
-
-  public readonly goBackLink: Locator;
 
   public readonly messageFormatting: TemplateMgmtMessageFormatting;
 
@@ -31,14 +29,11 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
     this.namingYourTemplate = page.locator(
       '[data-testid="how-to-name-your-template"]'
     );
-    this.goBackLink = page
-      .locator('.nhsuk-back-link__link')
-      .and(page.getByText('Back to choose a template type'));
 
     this.messageFormatting = new TemplateMgmtMessageFormatting(page);
   }
 
-  async loadPage() {
-    await this.navigateTo('/templates/create-email-template');
+  async loadPage(templateId: string) {
+    await this.navigateTo(`/templates/edit-email-template/${templateId}`);
   }
 }

--- a/tests/test-team/pages/nhs-app/template-mgmt-create-nhs-app-page.ts
+++ b/tests/test-team/pages/nhs-app/template-mgmt-create-nhs-app-page.ts
@@ -37,11 +37,7 @@ export class TemplateMgmtCreateNhsAppPage extends TemplateMgmtBasePage {
     this.messageFormatting = new TemplateMgmtMessageFormatting(page);
   }
 
-  async loadPage(templateId?: string) {
-    await this.navigateTo(
-      templateId
-        ? `/templates/edit-nhs-app-template/${templateId}`
-        : '/templates/create-nhs-app-template'
-    );
+  async loadPage() {
+    await this.navigateTo('/templates/create-nhs-app-template');
   }
 }

--- a/tests/test-team/pages/nhs-app/template-mgmt-edit-nhs-app-page.ts
+++ b/tests/test-team/pages/nhs-app/template-mgmt-edit-nhs-app-page.ts
@@ -2,10 +2,8 @@ import { Locator, Page } from '@playwright/test';
 import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
 
-export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditNhsAppPage extends TemplateMgmtBasePage {
   public readonly nameInput: Locator;
-
-  public readonly subjectLineInput: Locator;
 
   public readonly messageTextArea: Locator;
 
@@ -15,15 +13,14 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
 
   public readonly namingYourTemplate: Locator;
 
-  public readonly goBackLink: Locator;
+  public readonly characterCountText: Locator;
 
   public readonly messageFormatting: TemplateMgmtMessageFormatting;
 
   constructor(page: Page) {
     super(page);
-    this.nameInput = page.locator('[id="emailTemplateName"]');
-    this.subjectLineInput = page.locator('[id="emailTemplateSubjectLine"]');
-    this.messageTextArea = page.locator('[id="emailTemplateMessage"]');
+    this.nameInput = page.locator('[id="nhsAppTemplateName"]');
+    this.messageTextArea = page.locator('[id="nhsAppTemplateMessage"]');
     this.errorSummary = page.locator('[class="nhsuk-error-summary"]');
     this.personalisationFields = page.locator(
       '[data-testid="personalisation-details"]'
@@ -31,14 +28,11 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
     this.namingYourTemplate = page.locator(
       '[data-testid="how-to-name-your-template"]'
     );
-    this.goBackLink = page
-      .locator('.nhsuk-back-link__link')
-      .and(page.getByText('Back to choose a template type'));
-
+    this.characterCountText = page.locator('[id="character-count"]');
     this.messageFormatting = new TemplateMgmtMessageFormatting(page);
   }
 
-  async loadPage() {
-    await this.navigateTo('/templates/create-email-template');
+  async loadPage(templateId: string) {
+    await this.navigateTo(`/templates/edit-nhs-app-template/${templateId}`);
   }
 }

--- a/tests/test-team/pages/sms/template-mgmt-create-sms-page.ts
+++ b/tests/test-team/pages/sms/template-mgmt-create-sms-page.ts
@@ -41,11 +41,7 @@ export class TemplateMgmtCreateSmsPage extends TemplateMgmtBasePage {
     this.messageFormatting = new TemplateMgmtMessageFormatting(page);
   }
 
-  async loadPage(templateId?: string) {
-    await this.navigateTo(
-      templateId
-        ? `/templates/edit-text-message-template/${templateId}`
-        : '/templates/create-text-message-template'
-    );
+  async loadPage() {
+    await this.navigateTo('/templates/create-text-message-template');
   }
 }

--- a/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
+++ b/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
@@ -37,6 +37,8 @@ export class TemplateMgmtEditSmsPage extends TemplateMgmtBasePage {
   }
 
   async loadPage(templateId: string) {
-    await this.navigateTo(`/templates/edit-text-message-template/${templateId}`);
+    await this.navigateTo(
+      `/templates/edit-text-message-template/${templateId}`
+    );
   }
 }

--- a/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
+++ b/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
@@ -2,10 +2,8 @@ import { Locator, Page } from '@playwright/test';
 import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
 
-export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditSmsPage extends TemplateMgmtBasePage {
   public readonly nameInput: Locator;
-
-  public readonly subjectLineInput: Locator;
 
   public readonly messageTextArea: Locator;
 
@@ -15,15 +13,16 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
 
   public readonly namingYourTemplate: Locator;
 
-  public readonly goBackLink: Locator;
+  public readonly pricingLink: Locator;
+
+  public readonly characterCountText: Locator;
 
   public readonly messageFormatting: TemplateMgmtMessageFormatting;
 
   constructor(page: Page) {
     super(page);
-    this.nameInput = page.locator('[id="emailTemplateName"]');
-    this.subjectLineInput = page.locator('[id="emailTemplateSubjectLine"]');
-    this.messageTextArea = page.locator('[id="emailTemplateMessage"]');
+    this.nameInput = page.locator('[id="smsTemplateName"]');
+    this.messageTextArea = page.locator('[id="smsTemplateMessage"]');
     this.errorSummary = page.locator('[class="nhsuk-error-summary"]');
     this.personalisationFields = page.locator(
       '[data-testid="personalisation-details"]'
@@ -31,14 +30,13 @@ export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
     this.namingYourTemplate = page.locator(
       '[data-testid="how-to-name-your-template"]'
     );
-    this.goBackLink = page
-      .locator('.nhsuk-back-link__link')
-      .and(page.getByText('Back to choose a template type'));
+    this.pricingLink = page.locator('[data-testid="sms-pricing-link"]');
+    this.characterCountText = page.locator('[id="character-count"]');
 
     this.messageFormatting = new TemplateMgmtMessageFormatting(page);
   }
 
-  async loadPage() {
-    await this.navigateTo('/templates/create-email-template');
+  async loadPage(templateId: string) {
+    await this.navigateTo(`/templates/edit-text-message-template/${templateId}`);
   }
 }

--- a/tests/test-team/template-mgmt-component-tests/email/template-mgmt-create-email-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/email/template-mgmt-create-email-page.component.spec.ts
@@ -34,9 +34,7 @@ test.describe('Create Email message template Page', () => {
 
     await createEmailTemplatePage.loadPage();
 
-    await expect(page).toHaveURL(
-      `${baseURL}/templates/create-email-template`
-    );
+    await expect(page).toHaveURL(`${baseURL}/templates/create-email-template`);
 
     expect(await createEmailTemplatePage.pageHeader.textContent()).toBe(
       'Create email template'
@@ -158,11 +156,9 @@ test.describe('Create Email message template Page', () => {
 
       await createEmailTemplatePage.clickSubmitButton();
 
-      const previewPageRegex = "\\/templates\\/preview-email-template\\/([0-9a-fA-F-]+)(?:\\?from=edit)?$";
+      const previewPageRegex = String.raw`\/templates\/preview-email-template\/([0-9a-fA-F-]+)(?:\?from=edit)?$`;
 
-      await expect(page).toHaveURL(
-        RegExp(previewPageRegex)
-      );
+      await expect(page).toHaveURL(new RegExp(previewPageRegex));
 
       const previewPageParts = page.url().match(previewPageRegex);
 

--- a/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
@@ -1,0 +1,357 @@
+import { test, expect } from '@playwright/test';
+import { TemplateStorageHelper } from '../../helpers/db/template-storage-helper';
+import { TemplateMgmtEditEmailPage } from '../../pages/email/template-mgmt-edit-email-page';
+import { TemplateFactory } from '../../helpers/factories/template-factory';
+import {
+  assertFooterLinks,
+  assertLogoutLink,
+  assertGoBackLinkNotPresent,
+  assertNotifyBannerLink,
+  assertSkipToMainContent,
+} from '../template-mgmt-common.steps';
+import { TemplateType } from '../../helpers/types';
+import {
+  createAuthHelper,
+  TestUserId,
+} from '../../helpers/auth/cognito-auth-helper';
+
+function createTemplates(owner: string) {
+  return {
+    empty: TemplateFactory.createEmailTemplate('empty-email-template', owner),
+    submit: TemplateFactory.createEmailTemplate('submit-email-template', owner),
+    submitAndReturn: TemplateFactory.createEmailTemplate(
+      'submit-and-return-create-email-template',
+      owner
+    ),
+    goBackAndReturn: TemplateFactory.createEmailTemplate(
+      'go-back-email-template',
+      owner
+    ),
+    noEmailTemplateType: TemplateFactory.create({
+      id: 'no-email-template-type-template',
+      templateType: TemplateType.NHS_APP,
+      owner,
+    }),
+    previousData: {
+      ...TemplateFactory.createEmailTemplate(
+        'previous-data-email-template',
+        owner
+      ),
+      name: 'previous-data-email-template',
+      subject: 'previous-data-email-template-subject-line',
+      message: 'previous-data-email-template-message',
+    },
+  };
+}
+
+test.describe('Edit Email message template Page', () => {
+  let templates: ReturnType<typeof createTemplates>;
+  const templateStorageHelper = new TemplateStorageHelper();
+
+  test.beforeAll(async () => {
+    const user = await createAuthHelper().getTestUser(TestUserId.User1);
+    templates = createTemplates(user.userId);
+    await templateStorageHelper.seedTemplateData(Object.values(templates));
+  });
+
+  test.afterAll(async () => {
+    await templateStorageHelper.deleteSeededTemplates();
+  });
+
+  test('when user visits page, then page is loaded', async ({
+    page,
+    baseURL,
+  }) => {
+    const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+    await editEmailTemplatePage.loadPage(templates.empty.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-email-template/${templates.empty.id}`
+    );
+
+    expect(await editEmailTemplatePage.pageHeader.textContent()).toBe(
+      'Create email template'
+    );
+  });
+
+  test.describe('Page functionality', () => {
+    test('common page tests', async ({ page, baseURL }) => {
+      const props = {
+        page: new TemplateMgmtEditEmailPage(page),
+        id: templates.empty.id,
+        baseURL,
+      };
+
+      await assertSkipToMainContent(props);
+      await assertNotifyBannerLink(props);
+      await assertLogoutLink(props);
+      await assertFooterLinks(props);
+      await assertGoBackLinkNotPresent(props);
+    });
+
+    test('when user visits page with previous data, then form fields retain previous data', async ({
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.previousData.id);
+
+      await expect(editEmailTemplatePage.nameInput).toHaveValue(
+        templates.previousData.name
+      );
+      await expect(editEmailTemplatePage.subjectLineInput).toHaveValue(
+        templates.previousData.subject
+      );
+      await expect(editEmailTemplatePage.messageTextArea).toHaveValue(
+        templates.previousData.message
+      );
+    });
+
+    test('when user clicks "Personalisation" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.goBackAndReturn.id);
+
+      await editEmailTemplatePage.personalisationFields.click();
+
+      await expect(
+        editEmailTemplatePage.personalisationFields
+      ).toHaveAttribute('open');
+    });
+
+    test('when user clicks "Message formatting" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.messageFormatting.assertDetailsOpen([
+        editEmailTemplatePage.messageFormatting.lineBreaksAndParagraphs,
+        editEmailTemplatePage.messageFormatting.headings,
+        editEmailTemplatePage.messageFormatting.bulletPoints,
+        editEmailTemplatePage.messageFormatting.numberedList,
+        editEmailTemplatePage.messageFormatting.horizontalLines,
+        editEmailTemplatePage.messageFormatting.linksAndUrls,
+      ]);
+    });
+
+    const moreInfoLinks = [
+      { name: 'Email messages (opens in a new tab)', url: 'features/emails' },
+      {
+        name: 'From and reply-to addresses (opens in a new tab)',
+        url: 'using-nhs-notify/tell-recipients-who-your-messages-are-from',
+      },
+      {
+        name: 'Delivery times (opens in a new tab)',
+        url: 'using-nhs-notify/delivery-times',
+      },
+    ];
+
+    for (const { name, url } of moreInfoLinks) {
+      test(`more info link: ${name}, navigates to correct page in new tab`, async ({
+        page,
+        baseURL,
+      }) => {
+        const editTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+        await editTemplatePage.loadPage(templates.empty.id);
+
+        const newTabPromise = page.waitForEvent('popup');
+
+        await page.getByRole('link', { name }).click();
+
+        const newTab = await newTabPromise;
+
+        await expect(newTab).toHaveURL(`${baseURL}/${url}`);
+      });
+    }
+
+    test('when user clicks "Naming your templates" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.namingYourTemplate.click({
+        position: { x: 0, y: 0 },
+      });
+      await expect(editEmailTemplatePage.namingYourTemplate).toHaveAttribute(
+        'open'
+      );
+    });
+
+    test('when user submits form with valid data, then the next page is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.submit.id);
+
+      await editEmailTemplatePage.nameInput.fill(
+        'This is an email template name'
+      );
+
+      await editEmailTemplatePage.subjectLineInput.fill(
+        'This is an email template subject line'
+      );
+
+      await editEmailTemplatePage.messageTextArea.fill(
+        'This is an email message'
+      );
+
+      await editEmailTemplatePage.clickSubmitButton();
+
+      await expect(page).toHaveURL(
+        `${baseURL}/templates/preview-email-template/${templates.submit.id}?from=edit`
+      );
+    });
+  });
+
+  test.describe('Error handling', () => {
+    test('when user visits page with mismatched template journey, then an invalid template error is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.noEmailTemplateType.id);
+
+      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
+    });
+
+    test('when user visits page with a fake template, then an invalid template error is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage('/fake-template-id');
+
+      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
+    });
+
+    test('when user submits form with no data, then errors are displayed', async ({
+      page,
+    }) => {
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.clickSubmitButton();
+
+      await expect(editEmailTemplatePage.errorSummary).toBeVisible();
+
+      await expect(
+        editEmailTemplatePage.errorSummary.locator('h2')
+      ).toHaveText('There is a problem');
+
+      await expect(
+        editEmailTemplatePage.errorSummary.locator(
+          `[href="#emailTemplateName"]`
+        )
+      ).toBeVisible();
+
+      await expect(
+        editEmailTemplatePage.errorSummary.locator(
+          `[href="#emailTemplateSubjectLine"]`
+        )
+      ).toBeVisible();
+
+      await expect(
+        editEmailTemplatePage.errorSummary.locator(
+          `[href="#emailTemplateMessage"]`
+        )
+      ).toBeVisible();
+    });
+
+    test('when user submits form with no "Template name", then an error is displayed', async ({
+      page,
+    }) => {
+      const errorMessage = 'Enter a template name';
+
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.subjectLineInput.fill(
+        'template-subject-line'
+      );
+
+      await editEmailTemplatePage.messageTextArea.fill('template-message');
+
+      await editEmailTemplatePage.clickSubmitButton();
+
+      const emailNameErrorLink = editEmailTemplatePage.errorSummary.locator(
+        `[href="#emailTemplateName"]`
+      );
+
+      await expect(emailNameErrorLink).toHaveText(errorMessage);
+
+      await emailNameErrorLink.click();
+
+      await expect(editEmailTemplatePage.nameInput).toBeFocused();
+    });
+
+    test('when user submits form with no "Template Subject line", then an error is displayed', async ({
+      page,
+    }) => {
+      const errorMessage = 'Enter a template subject line';
+
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.nameInput.fill('template-name');
+
+      await editEmailTemplatePage.messageTextArea.fill('template-message');
+
+      await editEmailTemplatePage.clickSubmitButton();
+
+      const emailSubjectLineErrorLink =
+        editEmailTemplatePage.errorSummary.locator(
+          '[href="#emailTemplateSubjectLine"]'
+        );
+
+      await expect(emailSubjectLineErrorLink).toHaveText(errorMessage);
+
+      await emailSubjectLineErrorLink.click();
+
+      await expect(editEmailTemplatePage.subjectLineInput).toBeFocused();
+    });
+
+    test('when user submits form with no "Template message", then an error is displayed', async ({
+      page,
+    }) => {
+      const errorMessage = 'Enter a template message';
+
+      const editEmailTemplatePage = new TemplateMgmtEditEmailPage(page);
+
+      await editEmailTemplatePage.loadPage(templates.empty.id);
+
+      await editEmailTemplatePage.nameInput.fill('template-name');
+
+      await editEmailTemplatePage.subjectLineInput.fill(
+        'template-subject-line'
+      );
+
+      await editEmailTemplatePage.clickSubmitButton();
+
+      const emailMessageErrorLink =
+        editEmailTemplatePage.errorSummary.locator(
+          '[href="#emailTemplateMessage"]'
+        );
+
+      await expect(emailMessageErrorLink).toHaveText(errorMessage);
+
+      await emailMessageErrorLink.click();
+
+      await expect(editEmailTemplatePage.messageTextArea).toBeFocused();
+    });
+  });
+});

--- a/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
@@ -117,9 +117,9 @@ test.describe('Edit Email message template Page', () => {
 
       await editEmailTemplatePage.personalisationFields.click();
 
-      await expect(
-        editEmailTemplatePage.personalisationFields
-      ).toHaveAttribute('open');
+      await expect(editEmailTemplatePage.personalisationFields).toHaveAttribute(
+        'open'
+      );
     });
 
     test('when user clicks "Message formatting" tool tips, then tool tips are displayed', async ({
@@ -157,15 +157,10 @@ test.describe('Edit Email message template Page', () => {
         baseURL,
       }) => {
         const editTemplatePage = new TemplateMgmtEditEmailPage(page);
-
-        await editTemplatePage.loadPage(templates.empty.id);
-
+        await editTemplatePage.loadPage('empty-email-template');
         const newTabPromise = page.waitForEvent('popup');
-
         await page.getByRole('link', { name }).click();
-
         const newTab = await newTabPromise;
-
         await expect(newTab).toHaveURL(`${baseURL}/${url}`);
       });
     }
@@ -247,9 +242,9 @@ test.describe('Edit Email message template Page', () => {
 
       await expect(editEmailTemplatePage.errorSummary).toBeVisible();
 
-      await expect(
-        editEmailTemplatePage.errorSummary.locator('h2')
-      ).toHaveText('There is a problem');
+      await expect(editEmailTemplatePage.errorSummary.locator('h2')).toHaveText(
+        'There is a problem'
+      );
 
       await expect(
         editEmailTemplatePage.errorSummary.locator(
@@ -342,10 +337,9 @@ test.describe('Edit Email message template Page', () => {
 
       await editEmailTemplatePage.clickSubmitButton();
 
-      const emailMessageErrorLink =
-        editEmailTemplatePage.errorSummary.locator(
-          '[href="#emailTemplateMessage"]'
-        );
+      const emailMessageErrorLink = editEmailTemplatePage.errorSummary.locator(
+        '[href="#emailTemplateMessage"]'
+      );
 
       await expect(emailMessageErrorLink).toHaveText(errorMessage);
 

--- a/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-create-nhs-app-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-create-nhs-app-template-page.component.spec.ts
@@ -48,7 +48,7 @@ test.describe('Create NHS App Template Page', () => {
     const createTemplatePage = new TemplateMgmtCreateNhsAppPage(page);
 
     await createTemplatePage.loadPage();
-    
+
     expect(await createTemplatePage.pageHeader.textContent()).toBe(
       'Create NHS App message template'
     );
@@ -72,7 +72,7 @@ test.describe('Create NHS App Template Page', () => {
     await page
       .locator('[id="nhsAppTemplateMessage"]')
       .fill('This is an NHS App message');
-    await createTemplatePage.clickSubmitButton();    
+    await createTemplatePage.clickSubmitButton();
 
     const previewPageRegex = "\\/templates\\/preview-nhs-app-template\\/([0-9a-fA-F-]+)(?:\\?from=edit)?$";
 

--- a/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-create-nhs-app-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-create-nhs-app-template-page.component.spec.ts
@@ -74,11 +74,9 @@ test.describe('Create NHS App Template Page', () => {
       .fill('This is an NHS App message');
     await createTemplatePage.clickSubmitButton();
 
-    const previewPageRegex = "\\/templates\\/preview-nhs-app-template\\/([0-9a-fA-F-]+)(?:\\?from=edit)?$";
+    const previewPageRegex = String.raw`\/templates\/preview-nhs-app-template\/([0-9a-fA-F-]+)(?:\?from=edit)?$`;
 
-    await expect(page).toHaveURL(
-      RegExp(previewPageRegex)
-    );
+    await expect(page).toHaveURL(new RegExp(previewPageRegex));
 
     const previewPageParts = page.url().match(previewPageRegex);
     expect(previewPageParts?.length).toEqual(2);

--- a/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
@@ -1,0 +1,289 @@
+import { test, expect } from '@playwright/test';
+import { TemplateMgmtEditNhsAppPage } from '../../pages/nhs-app/template-mgmt-edit-nhs-app-page';
+import { TemplateFactory } from '../../helpers/factories/template-factory';
+import { TemplateStorageHelper } from '../../helpers/db/template-storage-helper';
+import {
+  assertFooterLinks,
+  assertLogoutLink,
+  assertGoBackLinkNotPresent,
+  assertNotifyBannerLink,
+  assertSkipToMainContent,
+} from '../template-mgmt-common.steps';
+import { Template } from '../../helpers/types';
+import {
+  createAuthHelper,
+  TestUserId,
+} from '../../helpers/auth/cognito-auth-helper';
+
+function createTemplates(owner: string) {
+  return {
+    emptyTemplateData: TemplateFactory.createNhsAppTemplate(
+      'empty-nhs-app-template',
+      owner
+    ),
+    submit: TemplateFactory.createNhsAppTemplate(
+      'submit-nhs-app-template',
+      owner
+    ),
+    submitAndReturn: TemplateFactory.createNhsAppTemplate(
+      'submit-and-return-nhs-app-template',
+      owner
+    ),
+  };
+}
+
+test.describe('Edit NHS App Template Page', () => {
+  const templateStorageHelper = new TemplateStorageHelper();
+  let templates: Record<string, Template>;
+
+  test.beforeAll(async () => {
+    const user = await createAuthHelper().getTestUser(TestUserId.User1);
+    templates = createTemplates(user.userId);
+    await templateStorageHelper.seedTemplateData(Object.values(templates));
+  });
+
+  test.afterAll(async () => {
+    await templateStorageHelper.deleteSeededTemplates();
+  });
+
+  test('should navigate to the NHS App template edit page when radio button selected', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+    expect(await editTemplatePage.pageHeader.textContent()).toBe(
+      'Create NHS App message template'
+    );
+  });
+
+  test('common page tests', async ({ page, baseURL }) => {
+    const props = {
+      page: new TemplateMgmtEditNhsAppPage(page),
+      id: templates.emptyTemplateData.id,
+      baseURL,
+    };
+
+    await assertSkipToMainContent(props);
+    await assertNotifyBannerLink(props);
+    await assertLogoutLink(props);
+    await assertFooterLinks(props);
+    await assertGoBackLinkNotPresent(props);
+  });
+
+  test('Validate error messages on the edit NHS App message template page with no template name or body', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+    expect(await editTemplatePage.pageHeader.textContent()).toBe(
+      'Create NHS App message template'
+    );
+    await editTemplatePage.clickSubmitButton();
+    await expect(page.locator('.nhsuk-error-summary')).toBeVisible();
+
+    await expect(
+      page.locator('ul[class="nhsuk-list nhsuk-error-summary__list"] > li')
+    ).toHaveText(['Enter a template name', 'Enter a template message']);
+  });
+
+  test('when user submits form with valid data, then the next page is displayed', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.submit.id);
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.submit.id}`
+    );
+    await page
+      .locator('[id="nhsAppTemplateName"]')
+      .fill('This is an NHS App template name');
+    await page
+      .locator('[id="nhsAppTemplateMessage"]')
+      .fill('This is an NHS App message');
+    await editTemplatePage.clickSubmitButton();
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/preview-nhs-app-template/${templates.submit.id}?from=edit`
+    );
+  });
+
+  test('Validate error messages on the edit NHS App message template page with a no template message', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+    expect(await editTemplatePage.pageHeader.textContent()).toBe(
+      'Create NHS App message template'
+    );
+    const templateName = 'NHS Testing 123';
+    await page.locator('[id="nhsAppTemplateName"]').fill(templateName);
+    await editTemplatePage.clickSubmitButton();
+    await expect(page.locator('.nhsuk-error-summary')).toBeVisible();
+    await expect(
+      page.locator('ul[class="nhsuk-list nhsuk-error-summary__list"] > li')
+    ).toHaveText(['Enter a template message']);
+  });
+
+  test('Validate error messages on the edit NHS App message template page with no template name', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+    expect(await editTemplatePage.pageHeader.textContent()).toBe(
+      'Create NHS App message template'
+    );
+    const templateMessage = 'Test Message box';
+    await page.locator('[id="nhsAppTemplateMessage"]').fill(templateMessage);
+    await editTemplatePage.clickSubmitButton();
+    await expect(page.locator('.nhsuk-error-summary')).toBeVisible();
+
+    await expect(
+      page.locator('ul[class="nhsuk-list nhsuk-error-summary__list"] > li')
+    ).toHaveText(['Enter a template name']);
+  });
+
+  test('5000 words Entered in Template body and word count correctly displayed', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+    await page.locator('[id="nhsAppTemplateName"]').fill('NHS Testing 123');
+    await page
+      .locator('[id="nhsAppTemplateMessage"]')
+      .fill('T'.repeat(5000).trim());
+    await expect(page.getByText('5000 of 5000 characters')).toBeVisible();
+  });
+
+  test('5001 words attempted to be entered in Template body and only 5000 allowed', async ({
+    page,
+    baseURL,
+  }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+    await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+    );
+
+    await page.locator('[id="nhsAppTemplateName"]').fill('NHS Testing 123');
+    await page
+      .locator('[id="nhsAppTemplateMessage"]')
+      .fill('T'.repeat(5001).trim());
+    await expect(page.getByText('5000 of 5000 characters')).toBeVisible();
+
+    const messageContent = await page
+      .getByRole('textbox', { name: 'Message' })
+      .textContent();
+
+    expect(messageContent).toHaveLength(5000);
+  });
+
+  const detailsSections = [
+    '[data-testid="personalisation-details"]',
+    '[data-testid="lines-breaks-and-paragraphs-details"]',
+    '[data-testid="headings-details"]',
+    '[data-testid="bold-text-details"]',
+    '[data-testid="link-and-url-details"]',
+    '[data-testid="how-to-name-your-template"]',
+  ];
+
+  for (const section of detailsSections) {
+    // eslint-disable-next-line no-loop-func
+    test(`when user clicks ${section} tool tip, then tool tip is displayed ${section}`, async ({
+      page,
+      baseURL,
+    }) => {
+      const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+      await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+      await expect(page).toHaveURL(
+        `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
+      );
+
+      await page.locator(`${section} > summary`).click();
+      await expect(page.locator(section)).toHaveAttribute('open');
+      await expect(page.locator(`${section} > div`)).toBeVisible();
+
+      await page.locator(`${section} > summary`).click();
+      await expect(page.locator(section)).not.toHaveAttribute('open');
+      await expect(page.locator(`${section} > div`)).toBeHidden();
+    });
+  }
+
+  const moreInfoLinks = [
+    {
+      name: 'NHS App messages (opens in a new tab)',
+      url: 'features/nhs-app-messages',
+    },
+    {
+      name: 'Delivery times (opens in a new tab)',
+      url: 'using-nhs-notify/delivery-times',
+    },
+    {
+      name: 'Sender IDs (opens in a new tab)',
+      url: 'using-nhs-notify/tell-recipients-who-your-messages-are-from',
+    },
+  ];
+
+  for (const { name, url } of moreInfoLinks) {
+    test(`more info link: ${name}, navigates to correct page in new tab`, async ({
+      page,
+      baseURL,
+    }) => {
+      const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+
+      await editTemplatePage.loadPage(templates.emptyTemplateData.id);
+
+      const newTabPromise = page.waitForEvent('popup');
+
+      await page.getByRole('link', { name }).click();
+
+      const newTab = await newTabPromise;
+
+      await expect(newTab).toHaveURL(`${baseURL}/${url}`);
+    });
+  }
+
+  test('Invalid template ID test', async ({ page, baseURL }) => {
+    const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
+    const invalidTemplateId = 'invalid-template-id';
+    await editTemplatePage.loadPage(invalidTemplateId);
+    const errorMessage = page.locator('.nhsuk-heading-xl');
+    await Promise.all([
+      expect(errorMessage).toBeVisible(),
+      expect(errorMessage).toHaveText('Sorry, we could not find that page'),
+      expect(page).toHaveURL(`${baseURL}/templates/invalid-template`),
+    ]);
+  });
+});

--- a/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
@@ -262,15 +262,10 @@ test.describe('Edit NHS App Template Page', () => {
       baseURL,
     }) => {
       const editTemplatePage = new TemplateMgmtEditNhsAppPage(page);
-
-      await editTemplatePage.loadPage(templates.emptyTemplateData.id);
-
+      await editTemplatePage.loadPage('empty-nhs-app-template');
       const newTabPromise = page.waitForEvent('popup');
-
       await page.getByRole('link', { name }).click();
-
       const newTab = await newTabPromise;
-
       await expect(newTab).toHaveURL(`${baseURL}/${url}`);
     });
   }

--- a/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-create-sms-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-create-sms-page.component.spec.ts
@@ -1,71 +1,38 @@
 import { test, expect } from '@playwright/test';
 import { TemplateStorageHelper } from '../../helpers/db/template-storage-helper';
 import { TemplateMgmtCreateSmsPage } from '../../pages/sms/template-mgmt-create-sms-page';
-import { TemplateFactory } from '../../helpers/factories/template-factory';
 import {
   assertFooterLinks,
   assertGoBackLink,
   assertLogoutLink,
-  assertGoBackLinkNotPresent,
   assertNotifyBannerLink,
   assertSkipToMainContent,
 } from '../template-mgmt-common.steps';
 import { Template, TemplateType } from '../../helpers/types';
 import {
   createAuthHelper,
+  TestUser,
   TestUserId,
 } from '../../helpers/auth/cognito-auth-helper';
 
-function createTemplates(owner: string) {
-  return {
-    empty: TemplateFactory.createSmsTemplate('empty-sms-template', owner),
-    submit: TemplateFactory.createSmsTemplate('submit-sms-template', owner),
-    submitAndReturn: TemplateFactory.createSmsTemplate(
-      'submit-and-return-create-sms-template',
-      owner
-    ),
-    goBackAndReturn: TemplateFactory.createSmsTemplate(
-      'go-back-sms-template',
-      owner
-    ),
-    noSmsTemplateType: TemplateFactory.create({
-      id: 'no-sms-template-type-template',
-      templateType: TemplateType.EMAIL,
-      owner,
-    }),
-    previousData: {
-      ...TemplateFactory.createSmsTemplate('previous-data-sms-template', owner),
-      name: 'previous-data-sms-template',
-      message: 'previous-data-sms-template-message',
-    },
-  };
-}
-
 test.describe('Create SMS message template Page', () => {
-  let templates: Record<string, Template>;
   const templateStorageHelper = new TemplateStorageHelper();
+  let user: TestUser;
 
   test.beforeAll(async () => {
-    const user = await createAuthHelper().getTestUser(TestUserId.User1);
-    templates = createTemplates(user.userId);
-    await templateStorageHelper.seedTemplateData(Object.values(templates));
+    user = await createAuthHelper().getTestUser(TestUserId.User1);
   });
 
   test.afterAll(async () => {
-    await templateStorageHelper.deleteSeededTemplates();
+    await templateStorageHelper.deleteAdHocTemplates();
   });
 
   test('when user visits page, then page is loaded', async ({
     page,
-    baseURL,
   }) => {
     const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-    await createSmsTemplatePage.loadPage(templates.empty.id);
-
-    await expect(page).toHaveURL(
-      `${baseURL}/templates/edit-text-message-template/${templates.empty.id}`
-    );
+    await createSmsTemplatePage.loadPage();
 
     expect(await createSmsTemplatePage.pageHeader.textContent()).toBe(
       'Create text message template'
@@ -94,35 +61,10 @@ test.describe('Create SMS message template Page', () => {
       });
     });
 
-    test('edit page has no go back link', async ({ page, baseURL }) => {
-      const props = {
-        page: new TemplateMgmtCreateSmsPage(page),
-        id: templates.empty.id,
-        baseURL,
-      };
-
-      await assertGoBackLinkNotPresent(props);
-    });
-
-    test('when user visits page with previous data, then form fields retain previous data', async ({
-      page,
-    }) => {
-      const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
-
-      await createSmsTemplatePage.loadPage(templates.previousData.id);
-
-      await expect(createSmsTemplatePage.nameInput).toHaveValue(
-        templates.previousData.name
-      );
-      await expect(createSmsTemplatePage.messageTextArea).toHaveValue(
-        templates.previousData.message
-      );
-    });
-
     test('character count', async ({ page }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.submit.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.nameInput.fill('template-name');
 
@@ -144,7 +86,7 @@ test.describe('Create SMS message template Page', () => {
     }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.goBackAndReturn.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.personalisationFields.click();
 
@@ -158,7 +100,7 @@ test.describe('Create SMS message template Page', () => {
     }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.empty.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.messageFormatting.assertDetailsOpen([
         createSmsTemplatePage.messageFormatting.linksAndUrls,
@@ -170,7 +112,7 @@ test.describe('Create SMS message template Page', () => {
     }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.empty.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.namingYourTemplate.click({
         position: { x: 0, y: 0 },
@@ -216,12 +158,11 @@ test.describe('Create SMS message template Page', () => {
     }
 
     test('when user submits form with valid data, then the next page is displayed', async ({
-      baseURL,
       page,
     }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.submit.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.nameInput.fill(
         'This is an SMS template name'
@@ -233,41 +174,28 @@ test.describe('Create SMS message template Page', () => {
 
       await createSmsTemplatePage.clickSubmitButton();
 
+      const previewPageRegex = "\\/templates\\/preview-text-message-template\\/([0-9a-fA-F-]+)(?:\\?from=edit)?$";
+
       await expect(page).toHaveURL(
-        `${baseURL}/templates/preview-text-message-template/${templates.submit.id}?from=edit`
+        RegExp(previewPageRegex)
       );
+
+      const previewPageParts = page.url().match(previewPageRegex);
+      expect(previewPageParts?.length).toEqual(2);
+      templateStorageHelper.addAdHocTemplateKey({
+        id: previewPageParts![1],
+        owner: user.userId,
+      });
     });
   });
 
   test.describe('Error handling', () => {
-    test('when user visits page with mismatched template journey, then an invalid template error is displayed', async ({
-      baseURL,
-      page,
-    }) => {
-      const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
-
-      await createSmsTemplatePage.loadPage(templates.noSmsTemplateType.id);
-
-      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
-    });
-
-    test('when user visits page with a fake template, then an invalid template error is displayed', async ({
-      baseURL,
-      page,
-    }) => {
-      const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
-
-      await createSmsTemplatePage.loadPage('/fake-template-id');
-
-      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
-    });
-
     test('when user submits form with no data, then errors are displayed', async ({
       page,
     }) => {
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.empty.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.clickSubmitButton();
 
@@ -295,7 +223,7 @@ test.describe('Create SMS message template Page', () => {
 
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.empty.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.messageTextArea.fill('template-message');
 
@@ -319,7 +247,7 @@ test.describe('Create SMS message template Page', () => {
 
       const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
-      await createSmsTemplatePage.loadPage(templates.empty.id);
+      await createSmsTemplatePage.loadPage();
 
       await createSmsTemplatePage.nameInput.fill('template-name');
 

--- a/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-create-sms-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-create-sms-page.component.spec.ts
@@ -8,7 +8,6 @@ import {
   assertNotifyBannerLink,
   assertSkipToMainContent,
 } from '../template-mgmt-common.steps';
-import { Template, TemplateType } from '../../helpers/types';
 import {
   createAuthHelper,
   TestUser,
@@ -27,9 +26,7 @@ test.describe('Create SMS message template Page', () => {
     await templateStorageHelper.deleteAdHocTemplates();
   });
 
-  test('when user visits page, then page is loaded', async ({
-    page,
-  }) => {
+  test('when user visits page, then page is loaded', async ({ page }) => {
     const createSmsTemplatePage = new TemplateMgmtCreateSmsPage(page);
 
     await createSmsTemplatePage.loadPage();
@@ -174,11 +171,9 @@ test.describe('Create SMS message template Page', () => {
 
       await createSmsTemplatePage.clickSubmitButton();
 
-      const previewPageRegex = "\\/templates\\/preview-text-message-template\\/([0-9a-fA-F-]+)(?:\\?from=edit)?$";
+      const previewPageRegex = String.raw`\/templates\/preview-text-message-template\/([0-9a-fA-F-]+)(?:\?from=edit)?$`;
 
-      await expect(page).toHaveURL(
-        RegExp(previewPageRegex)
-      );
+      await expect(page).toHaveURL(new RegExp(previewPageRegex));
 
       const previewPageParts = page.url().match(previewPageRegex);
       expect(previewPageParts?.length).toEqual(2);

--- a/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
@@ -1,0 +1,326 @@
+import { test, expect } from '@playwright/test';
+import { TemplateStorageHelper } from '../../helpers/db/template-storage-helper';
+import { TemplateMgmtEditSmsPage } from '../../pages/sms/template-mgmt-edit-sms-page';
+import { TemplateFactory } from '../../helpers/factories/template-factory';
+import {
+  assertFooterLinks,
+  assertLogoutLink,
+  assertGoBackLinkNotPresent,
+  assertNotifyBannerLink,
+  assertSkipToMainContent,
+} from '../template-mgmt-common.steps';
+import { Template, TemplateType } from '../../helpers/types';
+import {
+  createAuthHelper,
+  TestUserId,
+} from '../../helpers/auth/cognito-auth-helper';
+
+function createTemplates(owner: string) {
+  return {
+    empty: TemplateFactory.createSmsTemplate('empty-sms-template', owner),
+    submit: TemplateFactory.createSmsTemplate('submit-sms-template', owner),
+    submitAndReturn: TemplateFactory.createSmsTemplate(
+      'submit-and-return-create-sms-template',
+      owner
+    ),
+    goBackAndReturn: TemplateFactory.createSmsTemplate(
+      'go-back-sms-template',
+      owner
+    ),
+    noSmsTemplateType: TemplateFactory.create({
+      id: 'no-sms-template-type-template',
+      templateType: TemplateType.EMAIL,
+      owner,
+    }),
+    previousData: {
+      ...TemplateFactory.createSmsTemplate('previous-data-sms-template', owner),
+      name: 'previous-data-sms-template',
+      message: 'previous-data-sms-template-message',
+    },
+  };
+}
+
+test.describe('Edit SMS message template Page', () => {
+  let templates: Record<string, Template>;
+  const templateStorageHelper = new TemplateStorageHelper();
+
+  test.beforeAll(async () => {
+    const user = await createAuthHelper().getTestUser(TestUserId.User1);
+    templates = createTemplates(user.userId);
+    await templateStorageHelper.seedTemplateData(Object.values(templates));
+  });
+
+  test.afterAll(async () => {
+    await templateStorageHelper.deleteSeededTemplates();
+  });
+
+  test('when user visits page, then page is loaded', async ({
+    page,
+    baseURL,
+  }) => {
+    const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+    await editSmsTemplatePage.loadPage(templates.empty.id);
+
+    await expect(page).toHaveURL(
+      `${baseURL}/templates/edit-text-message-template/${templates.empty.id}`
+    );
+
+    expect(await editSmsTemplatePage.pageHeader.textContent()).toBe(
+      'Create text message template'
+    );
+
+    await expect(editSmsTemplatePage.pricingLink).toHaveAttribute(
+      'href',
+      '/pricing/text-messages'
+    );
+  });
+
+  test.describe('Page functionality', () => {
+    test('common page tests', async ({ page, baseURL }) => {
+      const props = {
+        page: new TemplateMgmtEditSmsPage(page),
+        id: templates.empty.id,
+        baseURL,
+      };
+
+      await assertSkipToMainContent(props);
+      await assertNotifyBannerLink(props);
+      await assertLogoutLink(props);
+      await assertFooterLinks(props);
+      await assertGoBackLinkNotPresent(props);
+    });
+
+    test('when user visits page with previous data, then form fields retain previous data', async ({
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.previousData.id);
+
+      await expect(editSmsTemplatePage.nameInput).toHaveValue(
+        templates.previousData.name
+      );
+      await expect(editSmsTemplatePage.messageTextArea).toHaveValue(
+        templates.previousData.message
+      );
+    });
+
+    test('character count', async ({ page }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.submit.id);
+
+      await editSmsTemplatePage.nameInput.fill('template-name');
+
+      await editSmsTemplatePage.messageTextArea.fill('a'.repeat(100));
+
+      await expect(editSmsTemplatePage.characterCountText).toHaveText(
+        '100 characters'
+      );
+
+      await editSmsTemplatePage.messageTextArea.fill('a'.repeat(1000));
+
+      await expect(editSmsTemplatePage.characterCountText).toHaveText(
+        '918 characters'
+      );
+    });
+
+    test('when user clicks "Personalisation" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.goBackAndReturn.id);
+
+      await editSmsTemplatePage.personalisationFields.click();
+
+      await expect(editSmsTemplatePage.personalisationFields).toHaveAttribute(
+        'open'
+      );
+    });
+
+    test('when user clicks "Message formatting" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.empty.id);
+
+      await editSmsTemplatePage.messageFormatting.assertDetailsOpen([
+        editSmsTemplatePage.messageFormatting.linksAndUrls,
+      ]);
+    });
+
+    test('when user clicks "Naming your templates" tool tips, then tool tips are displayed', async ({
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.empty.id);
+
+      await editSmsTemplatePage.namingYourTemplate.click({
+        position: { x: 0, y: 0 },
+      });
+
+      await expect(editSmsTemplatePage.namingYourTemplate).toHaveAttribute(
+        'open'
+      );
+    });
+
+    const moreInfoLinks = [
+      {
+        name: 'Text message length and pricing (opens in a new tab)',
+        url: 'pricing/text-messages',
+      },
+      {
+        name: 'Sender IDs (opens in a new tab)',
+        url: 'using-nhs-notify/tell-recipients-who-your-messages-are-from',
+      },
+      {
+        name: 'Delivery times (opens in a new tab)',
+        url: 'using-nhs-notify/delivery-times',
+      },
+    ];
+
+    for (const { name, url } of moreInfoLinks) {
+      test(`more info link: ${name}, navigates to correct page in new tab`, async ({
+        page,
+        baseURL,
+      }) => {
+        const editTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+        await editTemplatePage.loadPage(templates.empty.id);
+
+        const newTabPromise = page.waitForEvent('popup');
+
+        await page.getByRole('link', { name }).click();
+
+        const newTab = await newTabPromise;
+
+        await expect(newTab).toHaveURL(`${baseURL}/${url}`);
+      });
+    }
+
+    test('when user submits form with valid data, then the next page is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.submit.id);
+
+      await editSmsTemplatePage.nameInput.fill(
+        'This is an SMS template name'
+      );
+
+      await editSmsTemplatePage.messageTextArea.fill(
+        'This is an SMS message'
+      );
+
+      await editSmsTemplatePage.clickSubmitButton();
+
+      await expect(page).toHaveURL(
+        `${baseURL}/templates/preview-text-message-template/${templates.submit.id}?from=edit`
+      );
+    });
+  });
+
+  test.describe('Error handling', () => {
+    test('when user visits page with mismatched template journey, then an invalid template error is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.noSmsTemplateType.id);
+
+      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
+    });
+
+    test('when user visits page with a fake template, then an invalid template error is displayed', async ({
+      baseURL,
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage('/fake-template-id');
+
+      await expect(page).toHaveURL(`${baseURL}/templates/invalid-template`);
+    });
+
+    test('when user submits form with no data, then errors are displayed', async ({
+      page,
+    }) => {
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.empty.id);
+
+      await editSmsTemplatePage.clickSubmitButton();
+
+      await expect(editSmsTemplatePage.errorSummary).toBeVisible();
+
+      await expect(editSmsTemplatePage.errorSummary.locator('h2')).toHaveText(
+        'There is a problem'
+      );
+
+      await expect(
+        editSmsTemplatePage.errorSummary.locator(`[href="#smsTemplateName"]`)
+      ).toBeVisible();
+
+      await expect(
+        editSmsTemplatePage.errorSummary.locator(
+          `[href="#smsTemplateMessage"]`
+        )
+      ).toBeVisible();
+    });
+
+    test('when user submits form with no "Template name", then an error is displayed', async ({
+      page,
+    }) => {
+      const errorMessage = 'Enter a template name';
+
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.empty.id);
+
+      await editSmsTemplatePage.messageTextArea.fill('template-message');
+
+      await editSmsTemplatePage.clickSubmitButton();
+
+      const smsNameErrorLink = editSmsTemplatePage.errorSummary.locator(
+        `[href="#smsTemplateName"]`
+      );
+
+      await expect(smsNameErrorLink).toHaveText(errorMessage);
+
+      await smsNameErrorLink.click();
+
+      await expect(editSmsTemplatePage.nameInput).toBeFocused();
+    });
+
+    test('when user submits form with no "Template message", then an error is displayed', async ({
+      page,
+    }) => {
+      const errorMessage = 'Enter a template message';
+
+      const editSmsTemplatePage = new TemplateMgmtEditSmsPage(page);
+
+      await editSmsTemplatePage.loadPage(templates.empty.id);
+
+      await editSmsTemplatePage.nameInput.fill('template-name');
+
+      await editSmsTemplatePage.clickSubmitButton();
+
+      const smsMessageErrorLink = editSmsTemplatePage.errorSummary.locator(
+        '[href="#smsTemplateMessage"]'
+      );
+
+      await expect(smsMessageErrorLink).toHaveText(errorMessage);
+
+      await smsMessageErrorLink.click();
+
+      await expect(editSmsTemplatePage.messageTextArea).toBeFocused();
+    });
+  });
+});

--- a/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
@@ -189,15 +189,10 @@ test.describe('Edit SMS message template Page', () => {
         baseURL,
       }) => {
         const editTemplatePage = new TemplateMgmtEditSmsPage(page);
-
-        await editTemplatePage.loadPage(templates.empty.id);
-
+        await editTemplatePage.loadPage('empty-sms-template');
         const newTabPromise = page.waitForEvent('popup');
-
         await page.getByRole('link', { name }).click();
-
         const newTab = await newTabPromise;
-
         await expect(newTab).toHaveURL(`${baseURL}/${url}`);
       });
     }
@@ -210,13 +205,9 @@ test.describe('Edit SMS message template Page', () => {
 
       await editSmsTemplatePage.loadPage(templates.submit.id);
 
-      await editSmsTemplatePage.nameInput.fill(
-        'This is an SMS template name'
-      );
+      await editSmsTemplatePage.nameInput.fill('This is an SMS template name');
 
-      await editSmsTemplatePage.messageTextArea.fill(
-        'This is an SMS message'
-      );
+      await editSmsTemplatePage.messageTextArea.fill('This is an SMS message');
 
       await editSmsTemplatePage.clickSubmitButton();
 
@@ -269,9 +260,7 @@ test.describe('Edit SMS message template Page', () => {
       ).toBeVisible();
 
       await expect(
-        editSmsTemplatePage.errorSummary.locator(
-          `[href="#smsTemplateMessage"]`
-        )
+        editSmsTemplatePage.errorSummary.locator(`[href="#smsTemplateMessage"]`)
       ).toBeVisible();
     });
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Add missing ui tests for the create template pages.

## Context

It was noted that we were only testing the edit template pages. This change adds ui tests to the create template pages.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## Test evidence

Passing pipeline [runs/13175330549/job/36773647159?pr=282](https://github.com/NHSDigital/nhs-notify-web-template-management/actions/runs/13175330549/job/36773647159?pr=282).

![image](https://github.com/user-attachments/assets/9770e256-4a61-4cdc-ba12-c9f8c7d0a3f7)

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
