### PR TITLE
Feat/CCM-7938 Updating version pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ tests/test-team/test-results/
 tests/test-team/playwright-report/
 tests/test-team/blob-report/
 tests/test-team/playwright/.cache/
+lambdas/backend-api/src/email/email-template.json

--- a/infrastructure/terraform/components/acct/module_s3bucket_backup_reports.tf
+++ b/infrastructure/terraform/components/acct/module_s3bucket_backup_reports.tf
@@ -1,5 +1,5 @@
 module "s3bucket_backup_reports" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/s3bucket?ref=v1.0.5"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/s3bucket?ref=v1.0.8"
 
   name = "backup-reports"
 
@@ -15,7 +15,6 @@ module "s3bucket_backup_reports" {
 
   lifecycle_rules = [
     {
-      prefix  = ""
       enabled = true
 
       noncurrent_version_transition = [

--- a/infrastructure/terraform/components/app/module_eventpub.tf
+++ b/infrastructure/terraform/components/app/module_eventpub.tf
@@ -1,0 +1,23 @@
+module "eventpub" {
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/eventpub?ref=v1.0.8"
+
+  name = "eventpub"
+
+  aws_account_id = var.aws_account_id
+  component      = var.component
+  environment    = var.environment
+  project        = var.project
+  region         = var.region
+  group          = var.group
+
+  log_retention_in_days = var.log_retention_in_days
+  kms_key_arn           = module.kms.key_arn
+
+  enable_event_cache = var.enable_event_caching
+
+  enable_sns_delivery_logging        = var.event_delivery_logging
+  sns_success_logging_sample_percent = var.event_delivery_logging_success_sample_percentage
+
+  data_plane_bus_arn    = var.data_plane_bus_arn
+  control_plane_bus_arn = var.control_plane_bus_arn
+}

--- a/infrastructure/terraform/components/app/module_kms.tf
+++ b/infrastructure/terraform/components/app/module_kms.tf
@@ -1,5 +1,5 @@
 module "kms" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/kms?ref=v1.0.6"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/kms?ref=v1.0.8"
 
   aws_account_id = var.aws_account_id
   component      = var.component

--- a/infrastructure/terraform/components/app/module_nhse_backup_vault.tf
+++ b/infrastructure/terraform/components/app/module_nhse_backup_vault.tf
@@ -1,5 +1,5 @@
 module "nhse_backup_vault" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/aws-backup-source?ref=v1.0.7"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/aws-backup-source?ref=v1.0.8"
   count = var.destination_vault_arn != null ? 1:0
 
   component   = var.component

--- a/infrastructure/terraform/components/app/variables.tf
+++ b/infrastructure/terraform/components/app/variables.tf
@@ -153,3 +153,31 @@ variable "backup_report_recipient" {
   description = "Primary recipient of the Backup reports"
   default     = ""
 }
+
+variable "enable_event_caching" {
+  type        = bool
+  description = "Enable caching of events to an S3 bucket"
+  default     = true
+}
+
+variable "event_delivery_logging" {
+  type        = bool
+  description = "Enable SNS Event Delivery logging"
+  default     = true
+}
+
+variable "event_delivery_logging_success_sample_percentage" {
+  type        = number
+  description = "Enable caching of events to an S3 bucket"
+  default     = 0
+}
+
+variable "data_plane_bus_arn" {
+  type        = string
+  description = "Data plane event bus arn"
+}
+
+variable "control_plane_bus_arn" {
+  type        = string
+  description = "Data plane event bus arn"
+}

--- a/infrastructure/terraform/components/branch/module_amplify_branch.tf
+++ b/infrastructure/terraform/components/branch/module_amplify_branch.tf
@@ -1,5 +1,5 @@
 module "amplify_branch" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/amp_branch?ref=v1.0.0"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/amp_branch?ref=v1.0.8"
 
   name         = local.normalised_branch_name
   display_name = local.normalised_branch_name


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Fixes 5.56 TF provider change for 'prefix' on S3 lifecycle policies
Increase shared module version pins
Introduces event publishing resources from shared module

Reliant on https://github.com/NHSDigital/nhs-notify-internal/pull/209 & https://github.com/NHSDigital/nhs-notify-eventbus/pull/29

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
