### PR TITLE
CCM-8590: add custom 404

### DIFF
--- a/frontend/src/__tests__/app/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/src/__tests__/app/__snapshots__/not-found.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InvalidTemplatePage 1`] = `
+<DocumentFragment>
+  <main
+    class="nhsuk-main-wrapper"
+    id="maincontent"
+    role="main"
+  >
+    <div
+      class="nhsuk-grid-row"
+      data-testid="page-content-wrapper"
+    >
+      <h1
+        class="nhsuk-heading-xl"
+        data-testid="page-heading"
+      >
+        Sorry, we could not find that page
+      </h1>
+      <p>
+        You may have typed or pasted a web address incorrectly. 
+        <a
+          href="/create-and-submit-templates"
+        >
+          Go to the start page.
+        </a>
+      </p>
+      <p>
+        If the web address is correct or you selected a link or button, contact us to let us know there is a problem with this page:
+      </p>
+      <h2
+        class="nhsuk-heading-m"
+      >
+        By email
+      </h2>
+      <p>
+        <a
+          href="mailto:ssd.nationalservicedesk@nhs.net"
+        >
+          ssd.nationalservicedesk@nhs.net
+        </a>
+      </p>
+    </div>
+  </main>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/app/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/src/__tests__/app/__snapshots__/not-found.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`InvalidTemplatePage 1`] = `
       <h1
         class="nhsuk-heading-xl"
         data-testid="page-heading"
+        id="not-found"
       >
         Sorry, we could not find that page
       </h1>

--- a/frontend/src/__tests__/app/invalid-template/__snapshots__/page.test.tsx.snap
+++ b/frontend/src/__tests__/app/invalid-template/__snapshots__/page.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`InvalidTemplatePage 1`] = `
       <h1
         class="nhsuk-heading-xl"
         data-testid="page-heading"
+        id="not-found"
       >
         Sorry, we could not find that page
       </h1>

--- a/frontend/src/__tests__/app/not-found.test.tsx
+++ b/frontend/src/__tests__/app/not-found.test.tsx
@@ -1,0 +1,8 @@
+import NotFound from '@app/not-found';
+import { render } from '@testing-library/react';
+
+test('InvalidTemplatePage', () => {
+  const container = render(<NotFound />);
+
+  expect(container.asFragment()).toMatchSnapshot();
+});

--- a/frontend/src/__tests__/components/molecules/__snapshots__/404.test.tsx.snap
+++ b/frontend/src/__tests__/components/molecules/__snapshots__/404.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`ErrorPage404 1`] = `
       <h1
         class="nhsuk-heading-xl"
         data-testid="page-heading"
+        id="not-found"
       >
         Sorry, we could not find that page
       </h1>

--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -26,10 +26,18 @@ describe('middleware function', () => {
     const response = await middleware(request);
 
     expect(response.status).toBe(307);
+    expect(response.headers.get('Content-Security-Policy')).toBeUndefined();
+  });
+
+  it('if request path is skipped, CSP is not applied', async () => {
+    const url = new URL('https://url.com/_next/static/script.js');
+    const request = new NextRequest(url);
+    const response = await middleware(request);
+
+    expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBe(
       'https://url.com/auth?redirect=%2Ftemplates%2F%2Fmanage-templates'
     );
-    expect(response.headers.get('Content-Type')).toBe('text/html');
   });
 
   it('if request path is protected, and access token is obtained, respond with CSP', async () => {

--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -37,15 +37,6 @@ describe('middleware function', () => {
     }
   );
 
-  it('if middleware is skipped for request path, CSP is not applied', async () => {
-    const url = new URL('https://url.com/_next/static/script.js');
-    const request = new NextRequest(url);
-    const response = await middleware(request);
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Security-Policy')).toBeNull();
-  });
-
   it('if request path is protected, and no access token is obtained, redirect to auth page', async () => {
     const url = new URL('https://url.com/manage-templates');
     const request = new NextRequest(url);

--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -20,6 +20,23 @@ afterAll(() => {
 });
 
 describe('middleware function', () => {
+  it.each([
+    'https://url.com/_next/static/script.js',
+    'https://url.com/_next/image/img.png',
+    'https://url.com/favicon.ico',
+    'https://url.com/lib/script.js',
+  ])(
+    'if middleware is skipped for request %s, CSP is not applied',
+    async (path) => {
+      const url = new URL(path);
+      const request = new NextRequest(url);
+      const response = await middleware(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Security-Policy')).toBeNull();
+    }
+  );
+
   it('if middleware is skipped for request path, CSP is not applied', async () => {
     const url = new URL('https://url.com/_next/static/script.js');
     const request = new NextRequest(url);

--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -20,21 +20,21 @@ afterAll(() => {
 });
 
 describe('middleware function', () => {
+  it('if middleware is skipped for request path, CSP is not applied', async () => {
+    const url = new URL('https://url.com/_next/static/script.js');
+    const request = new NextRequest(url);
+    const response = await middleware(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Security-Policy')).toBeNull();
+  });
+
   it('if request path is protected, and no access token is obtained, redirect to auth page', async () => {
     const url = new URL('https://url.com/manage-templates');
     const request = new NextRequest(url);
     const response = await middleware(request);
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('Content-Security-Policy')).toBeUndefined();
-  });
-
-  it('if request path is skipped, CSP is not applied', async () => {
-    const url = new URL('https://url.com/_next/static/script.js');
-    const request = new NextRequest(url);
-    const response = await middleware(request);
-
-    expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBe(
       'https://url.com/auth?redirect=%2Ftemplates%2F%2Fmanage-templates'
     );

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { ErrorPage404 } from '@molecules/404/404';
+
+export default function NotFound() {
+  return <ErrorPage404 />;
+}

--- a/frontend/src/components/molecules/404/404.tsx
+++ b/frontend/src/components/molecules/404/404.tsx
@@ -10,7 +10,11 @@ export const ErrorPage404 = () => {
   return (
     <NHSNotifyMain>
       <div className='nhsuk-grid-row' data-testid='page-content-wrapper'>
-        <h1 className='nhsuk-heading-xl' data-testid='page-heading'>
+        <h1
+          id='not-found'
+          className='nhsuk-heading-xl'
+          data-testid='page-heading'
+        >
           {error404PageContent.pageHeading}
         </h1>
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -57,7 +57,7 @@ export async function middleware(request: NextRequest) {
   const token = await getAccessTokenServer();
 
   if (!token) {
-    const redirectResponse = NextResponse.redirect(
+    return NextResponse.redirect(
       new URL(
         `/auth?redirect=${encodeURIComponent(
           `${getBasePath()}/${request.nextUrl.pathname}`
@@ -65,10 +65,6 @@ export async function middleware(request: NextRequest) {
         request.url
       )
     );
-
-    redirectResponse.headers.set('Content-Type', 'text/html');
-
-    return redirectResponse;
   }
 
   const response = NextResponse.next({

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -9,6 +9,8 @@ const middlewareSkipPaths = [
   '/lib/',
 ];
 
+const publicPaths = ['/create-and-submit-templates', '/auth'];
+
 function getContentSecurityPolicy(nonce: string) {
   const contentSecurityPolicyDirective = {
     'base-uri': [`'self'`],
@@ -35,10 +37,6 @@ function getContentSecurityPolicy(nonce: string) {
     .join('; ');
 }
 
-function isPublicPath(path: string, publicPaths: string[]): boolean {
-  return publicPaths.some((publicPath) => path.startsWith(publicPath));
-}
-
 export async function middleware(request: NextRequest) {
   if (
     middlewareSkipPaths.some((prefix) =>
@@ -55,9 +53,9 @@ export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('Content-Security-Policy', csp);
 
-  const publicPaths = ['/create-and-submit-templates', '/auth'];
-
-  if (isPublicPath(request.nextUrl.pathname, publicPaths)) {
+  if (
+    publicPaths.some((prefix) => request.nextUrl.pathname.startsWith(prefix))
+  ) {
     const publicPathResponse = NextResponse.next({
       request: {
         headers: requestHeaders,

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,7 +4,7 @@ import { getBasePath } from '@utils/get-base-path';
 
 const middlewareSkipPaths = [
   '/_next/static',
-  '_next/image',
+  '/_next/image',
   '/favicon.ico',
   '/lib/',
 ];

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,7 +6,7 @@ const middlewareSkipPaths = [
   '/_next/static',
   '_next/image',
   '/favicon.ico',
-  '/lib',
+  '/lib/',
 ];
 
 function getContentSecurityPolicy(nonce: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9348,7 +9348,6 @@
       "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -9357,7 +9356,6 @@
       "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -24357,14 +24355,12 @@
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -24380,7 +24376,6 @@
       "version": "5.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -24389,7 +24384,6 @@
       "version": "4.3.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -24404,7 +24398,6 @@
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -24412,14 +24405,12 @@
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -24429,7 +24420,6 @@
       "version": "1.6.3",
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -24438,7 +24428,6 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -24449,38 +24438,32 @@
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.0.3",
       "inBundle": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -24493,14 +24476,12 @@
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -24509,7 +24490,6 @@
       "version": "3.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -24517,14 +24497,12 @@
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -24536,7 +24514,6 @@
       "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -24544,14 +24521,12 @@
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -24560,7 +24535,6 @@
       "version": "2.1.35",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -24572,7 +24546,6 @@
       "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -24584,7 +24557,6 @@
       "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -24593,7 +24565,6 @@
       "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24602,7 +24573,6 @@
       "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -24614,7 +24584,6 @@
       "version": "4.0.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -24631,7 +24600,6 @@
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -24645,7 +24613,6 @@
       "version": "6.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -24657,7 +24624,6 @@
       "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -24673,7 +24639,6 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -24682,7 +24647,6 @@
       "version": "1.10.2",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }

--- a/tests/accessibility/.pa11y-ci.js
+++ b/tests/accessibility/.pa11y-ci.js
@@ -40,53 +40,53 @@ const manageTemplatesUrl = `${baseUrl}/manage-templates`;
 module.exports = {
   urls: [
     performCheck(nonExistentPage('http://localhost:3000/some-404')),
-    // performCheck({ url: startUrl, name: 'landing-page' }),
+    performCheck({ url: startUrl, name: 'landing-page' }),
 
-    // //My Messages Templates
-    // performCheck(manageTemplatesPage(manageTemplatesUrl)),
-    // performCheck(copyTemplatePage(chooseTemplateUrl)),
+    //My Messages Templates
+    performCheck(manageTemplatesPage(manageTemplatesUrl)),
+    performCheck(copyTemplatePage(chooseTemplateUrl)),
 
-    // // Choose a template journey
-    // performCheck(chooseATemplatePage(chooseTemplateUrl)),
-    // performCheck(chooseATemplatePageError(chooseTemplateUrl)),
+    // Choose a template journey
+    performCheck(chooseATemplatePage(chooseTemplateUrl)),
+    performCheck(chooseATemplatePageError(chooseTemplateUrl)),
 
-    // // NHS App journey
-    // performCheck(createNHSAppTemplatePage(chooseTemplateUrl)),
-    // performCheck(createNHSAppTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(reviewNHSAppTemplatePage(chooseTemplateUrl)),
-    // performCheck(reviewNHSAppTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(viewNotYetSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
-    // performCheck(submitNHSAppTemplatePage(chooseTemplateUrl)),
-    // performCheck(NhsAppTemplateSubmittedPage(chooseTemplateUrl)),
-    // performCheck(viewSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
+    // NHS App journey
+    performCheck(createNHSAppTemplatePage(chooseTemplateUrl)),
+    performCheck(createNHSAppTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(reviewNHSAppTemplatePage(chooseTemplateUrl)),
+    performCheck(reviewNHSAppTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(viewNotYetSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
+    performCheck(submitNHSAppTemplatePage(chooseTemplateUrl)),
+    performCheck(NhsAppTemplateSubmittedPage(chooseTemplateUrl)),
+    performCheck(viewSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
 
-    // // Text message journey
-    // performCheck(createTextMessageTemplatePage(chooseTemplateUrl)),
-    // performCheck(createTextMessageTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(reviewTextMessageTemplatePage(chooseTemplateUrl)),
-    // performCheck(reviewTextMessageTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(
-    //   viewNotYetSubmittedTextMessageTemplatePage(manageTemplatesUrl)
-    // ),
-    // performCheck(submitTextMessageTemplatePage(chooseTemplateUrl)),
-    // performCheck(textMessageTemplateSubmittedPage(chooseTemplateUrl)),
-    // performCheck(viewSubmittedTextMessageTemplatePage(manageTemplatesUrl)),
+    // Text message journey
+    performCheck(createTextMessageTemplatePage(chooseTemplateUrl)),
+    performCheck(createTextMessageTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(reviewTextMessageTemplatePage(chooseTemplateUrl)),
+    performCheck(reviewTextMessageTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(
+      viewNotYetSubmittedTextMessageTemplatePage(manageTemplatesUrl)
+    ),
+    performCheck(submitTextMessageTemplatePage(chooseTemplateUrl)),
+    performCheck(textMessageTemplateSubmittedPage(chooseTemplateUrl)),
+    performCheck(viewSubmittedTextMessageTemplatePage(manageTemplatesUrl)),
 
-    // // Email journey
-    // performCheck(createEmailTemplatePage(chooseTemplateUrl)),
-    // performCheck(createEmailTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(reviewEmailTemplatePage(chooseTemplateUrl)),
-    // performCheck(reviewEmailTemplateErrorPage(chooseTemplateUrl)),
-    // performCheck(viewNotYetSubmittedEmailTemplatePage(manageTemplatesUrl)),
-    // performCheck(submitEmailTemplatePage(chooseTemplateUrl)),
-    // performCheck(emailTemplateSubmittedPage(chooseTemplateUrl)),
-    // performCheck(viewSubmittedEmailTemplatePage(manageTemplatesUrl)),
+    // Email journey
+    performCheck(createEmailTemplatePage(chooseTemplateUrl)),
+    performCheck(createEmailTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(reviewEmailTemplatePage(chooseTemplateUrl)),
+    performCheck(reviewEmailTemplateErrorPage(chooseTemplateUrl)),
+    performCheck(viewNotYetSubmittedEmailTemplatePage(manageTemplatesUrl)),
+    performCheck(submitEmailTemplatePage(chooseTemplateUrl)),
+    performCheck(emailTemplateSubmittedPage(chooseTemplateUrl)),
+    performCheck(viewSubmittedEmailTemplatePage(manageTemplatesUrl)),
 
-    // performCheck({
-    //   url: `${baseUrl}/invalid-template`,
-    //   actions: [...signInPageActions, 'wait for h1 to be visible'],
-    //   name: 'invalid-template',
-    // }),
+    performCheck({
+      url: `${baseUrl}/invalid-template`,
+      actions: [...signInPageActions, 'wait for h1 to be visible'],
+      name: 'invalid-template',
+    }),
   ],
   defaults: {
     reporters: [

--- a/tests/accessibility/.pa11y-ci.js
+++ b/tests/accessibility/.pa11y-ci.js
@@ -29,6 +29,7 @@ const {
   viewSubmittedTextMessageTemplatePage,
   copyTemplatePage,
   signInPageActions,
+  nonExistentPage,
 } = require('./actions');
 
 const baseUrl = 'http://localhost:3000/templates';
@@ -38,48 +39,54 @@ const manageTemplatesUrl = `${baseUrl}/manage-templates`;
 
 module.exports = {
   urls: [
-    performCheck({ url: 'http://localhost:3000/some-404', name: '404-test' }),
-    performCheck({ url: startUrl, name: 'landing-page' }),
+    performCheck(nonExistentPage('http://localhost:3000/some-404')),
+    // performCheck({ url: startUrl, name: 'landing-page' }),
 
-    //My Messages Templates
-    performCheck(manageTemplatesPage(manageTemplatesUrl)),
-    performCheck(copyTemplatePage(chooseTemplateUrl)),
+    // //My Messages Templates
+    // performCheck(manageTemplatesPage(manageTemplatesUrl)),
+    // performCheck(copyTemplatePage(chooseTemplateUrl)),
 
-    // Choose a template journey
-    performCheck(chooseATemplatePage(chooseTemplateUrl)),
-    performCheck(chooseATemplatePageError(chooseTemplateUrl)),
+    // // Choose a template journey
+    // performCheck(chooseATemplatePage(chooseTemplateUrl)),
+    // performCheck(chooseATemplatePageError(chooseTemplateUrl)),
 
-    // NHS App journey
-    performCheck(createNHSAppTemplatePage(chooseTemplateUrl)),
-    performCheck(createNHSAppTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(reviewNHSAppTemplatePage(chooseTemplateUrl)),
-    performCheck(reviewNHSAppTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(viewNotYetSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
-    performCheck(submitNHSAppTemplatePage(chooseTemplateUrl)),
-    performCheck(NhsAppTemplateSubmittedPage(chooseTemplateUrl)),
-    performCheck(viewSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
+    // // NHS App journey
+    // performCheck(createNHSAppTemplatePage(chooseTemplateUrl)),
+    // performCheck(createNHSAppTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(reviewNHSAppTemplatePage(chooseTemplateUrl)),
+    // performCheck(reviewNHSAppTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(viewNotYetSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
+    // performCheck(submitNHSAppTemplatePage(chooseTemplateUrl)),
+    // performCheck(NhsAppTemplateSubmittedPage(chooseTemplateUrl)),
+    // performCheck(viewSubmittedNHSAppTemplatePage(manageTemplatesUrl)),
 
-    // Text message journey
-    performCheck(createTextMessageTemplatePage(chooseTemplateUrl)),
-    performCheck(createTextMessageTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(reviewTextMessageTemplatePage(chooseTemplateUrl)),
-    performCheck(reviewTextMessageTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(viewNotYetSubmittedTextMessageTemplatePage(manageTemplatesUrl)),
-    performCheck(submitTextMessageTemplatePage(chooseTemplateUrl)),
-    performCheck(textMessageTemplateSubmittedPage(chooseTemplateUrl)),
-    performCheck(viewSubmittedTextMessageTemplatePage(manageTemplatesUrl)),
+    // // Text message journey
+    // performCheck(createTextMessageTemplatePage(chooseTemplateUrl)),
+    // performCheck(createTextMessageTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(reviewTextMessageTemplatePage(chooseTemplateUrl)),
+    // performCheck(reviewTextMessageTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(
+    //   viewNotYetSubmittedTextMessageTemplatePage(manageTemplatesUrl)
+    // ),
+    // performCheck(submitTextMessageTemplatePage(chooseTemplateUrl)),
+    // performCheck(textMessageTemplateSubmittedPage(chooseTemplateUrl)),
+    // performCheck(viewSubmittedTextMessageTemplatePage(manageTemplatesUrl)),
 
-    // Email journey
-    performCheck(createEmailTemplatePage(chooseTemplateUrl)),
-    performCheck(createEmailTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(reviewEmailTemplatePage(chooseTemplateUrl)),
-    performCheck(reviewEmailTemplateErrorPage(chooseTemplateUrl)),
-    performCheck(viewNotYetSubmittedEmailTemplatePage(manageTemplatesUrl)),
-    performCheck(submitEmailTemplatePage(chooseTemplateUrl)),
-    performCheck(emailTemplateSubmittedPage(chooseTemplateUrl)),
-    performCheck(viewSubmittedEmailTemplatePage(manageTemplatesUrl)),
+    // // Email journey
+    // performCheck(createEmailTemplatePage(chooseTemplateUrl)),
+    // performCheck(createEmailTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(reviewEmailTemplatePage(chooseTemplateUrl)),
+    // performCheck(reviewEmailTemplateErrorPage(chooseTemplateUrl)),
+    // performCheck(viewNotYetSubmittedEmailTemplatePage(manageTemplatesUrl)),
+    // performCheck(submitEmailTemplatePage(chooseTemplateUrl)),
+    // performCheck(emailTemplateSubmittedPage(chooseTemplateUrl)),
+    // performCheck(viewSubmittedEmailTemplatePage(manageTemplatesUrl)),
 
-    performCheck({ url: `${baseUrl}/invalid-template`, actions: [...signInPageActions, 'wait for h1 to be visible'], name: 'invalid-template'}),
+    // performCheck({
+    //   url: `${baseUrl}/invalid-template`,
+    //   actions: [...signInPageActions, 'wait for h1 to be visible'],
+    //   name: 'invalid-template',
+    // }),
   ],
   defaults: {
     reporters: [
@@ -88,18 +95,15 @@ module.exports = {
         'pa11y-ci-reporter-html',
         {
           destination: './.reports/accessibility',
-          includeZeroIssues: true
-        }
+          includeZeroIssues: true,
+        },
       ],
     ],
-    rules: [
-      'Principle1.Guideline1_3.1_3_1_AAA',
-    ],
+    rules: ['Principle1.Guideline1_3.1_3_1_AAA'],
     chromeLaunchConfig: {
-      args: ['--no-sandbox']
+      args: ['--no-sandbox'],
     },
     standard: 'WCAG2AA',
     agent: 'pa11y',
-  }
+  },
 };
-

--- a/tests/accessibility/actions/index.js
+++ b/tests/accessibility/actions/index.js
@@ -21,4 +21,5 @@ module.exports = {
   ...require('./view-submitted-text-message-template.actions'),
   ...require('./copy-template.actions'),
   ...require('./sign-in-page.actions'),
+  ...require('./non-existent-page.actions'),
 };

--- a/tests/accessibility/actions/non-existent-page.actions.js
+++ b/tests/accessibility/actions/non-existent-page.actions.js
@@ -1,0 +1,16 @@
+const { signInPageActions } = require('./sign-in-page.actions');
+
+const pageActions = [
+  ...signInPageActions,
+  'wait for element #not-found to be visible',
+];
+
+const nonExistentPage = (url) => ({
+  name: '404-test',
+  url,
+  actions: pageActions,
+});
+
+module.exports = {
+  nonExistentPage,
+};

--- a/tests/accessibility/actions/sign-in-page.actions.js
+++ b/tests/accessibility/actions/sign-in-page.actions.js
@@ -10,5 +10,5 @@ const signInPageActions = [
 ];
 
 module.exports = {
-    signInPageActions,
+  signInPageActions,
 };


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds a custom 404 page. The default next 404 is rendered at build time, so it lacks per-request nonces, causing scripts and styles to be blocked.

For some reason, when using a middleware [matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher) next middleware does not run for certain requests, even if the matcher is completely unrestrictive (`/(.*)`). This affected the new 404 page. I have switched to using a conditional statement to skip middleware instead. 

It might be worth trying to reverse this once we're on nextJs 15

Changes to pa11y are due to middleware now running for non-existent pages (including those not following `templates/`) causing a login redirect. The test previously depended on access to the 404 page without login, which is not possible now.

I've removed a line in middleware which added a content type to redirects. This was originally added because the ZAP scan raises an alert for 'missing content type header' on redirects, since they have a request body, however, this might cause some unexpected behaviour and it seems better to leave it out. 

There is [another PR](https://github.com/NHSDigital/nhs-notify-system-tests/pull/35) to ignore the rule in the security test.

https://main.web-gateway.dev.nhsnotify.national.nhs.uk/templates~featureccm-8590-404-csp

<img width="1336" alt="Screenshot 2025-02-13 at 16 06 26" src="https://github.com/user-attachments/assets/b1ddf367-6655-4e70-9698-1eff574c1b5e" />


## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
