### PR TITLE
CCM-8590: public 404

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -20,6 +20,14 @@ afterAll(() => {
 });
 
 describe('middleware function', () => {
+  it('If route is not registered in midleware, respond with 404', async () => {
+    const url = new URL('https://url.com/manage-templates/does-not-exist');
+    const request = new NextRequest(url);
+    const response = await middleware(request);
+
+    expect(response.status).toBe(404);
+  });
+
   it('if request path is protected, and no access token is obtained, redirect to auth page', async () => {
     const url = new URL('https://url.com/manage-templates');
     const request = new NextRequest(url);

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,6 +2,39 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { getAccessTokenServer } from '@utils/amplify-utils';
 import { getBasePath } from '@utils/get-base-path';
 
+const protectedPaths = [
+  /^\/choose-a-template-type$/,
+  /^\/copy-template\/[^/]+$/,
+  /^\/create-email-template$/,
+  /^\/create-nhs-app-template$/,
+  /^\/create-text-message-template$/,
+  /^\/delete-template\/[^/]+$/,
+  /^\/edit-email-template\/[^/]+$/,
+  /^\/edit-nhs-app-template/,
+  /^\/edit-text-message-template\/[^/]+$/,
+  /^\/email-template-submitted\/[^/]+$/,
+  /^\/invalid-template$/,
+  /^\/manage-templates$/,
+  /^\/nhs-app-template-submitted\/[^/]+$/,
+  /^\/preview-email-template\/[^/]+$/,
+  /^\/preview-nhs-app-template\/[^/]+$/,
+  /^\/preview-text-message-template\/[^/]+$/,
+  /^\/submit-email-template\/[^/]+$/,
+  /^\/submit-nhs-app-template\/[^/]+$/,
+  /^\/submit-text-message-template\/[^/]+$/,
+  /^\/text-message-template-submitted\/[^/]+$/,
+  /^\/view-submitted-email-template\/[^/]+$/,
+  /^\/view-submitted-nhs-app-template\/[^/]+$/,
+  /^\/view-submitted-text-message-template\/[^/]+$/,
+];
+
+const publicPaths = [
+  /^\/create-and-submit-templates$/,
+  /^\/auth$/,
+  /^\/auth\/signin$/,
+  /^\/auth\/signout$/,
+];
+
 function getContentSecurityPolicy(nonce: string) {
   const contentSecurityPolicyDirective = {
     'base-uri': [`'self'`],
@@ -28,11 +61,9 @@ function getContentSecurityPolicy(nonce: string) {
     .join('; ');
 }
 
-function isPublicPath(path: string, publicPaths: string[]): boolean {
-  return publicPaths.some((publicPath) => path.startsWith(publicPath));
-}
-
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
 
   const csp = getContentSecurityPolicy(nonce);
@@ -40,9 +71,7 @@ export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('Content-Security-Policy', csp);
 
-  const publicPaths = ['/create-and-submit-templates', '/auth', '/lib'];
-
-  if (isPublicPath(request.nextUrl.pathname, publicPaths)) {
+  if (publicPaths.some((p) => p.test(pathname))) {
     const publicPathResponse = NextResponse.next({
       request: {
         headers: requestHeaders,
@@ -52,6 +81,10 @@ export async function middleware(request: NextRequest) {
     publicPathResponse.headers.set('Content-Security-Policy', csp);
 
     return publicPathResponse;
+  }
+
+  if (!protectedPaths.some((p) => p.test(pathname))) {
+    return new NextResponse('Page not found', { status: 404 });
   }
 
   const token = await getAccessTokenServer();

--- a/tests/test-team/pages/email/template-mgmt-create-email-page.ts
+++ b/tests/test-team/pages/email/template-mgmt-create-email-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageNonDynamic } from '../template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePage {
+export class TemplateMgmtCreateEmailPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'create-email-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/email/template-mgmt-edit-email-page.ts
+++ b/tests/test-team/pages/email/template-mgmt-edit-email-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageDynamic } from '../template-mgmt-base-page-dynamic';
 
-export class TemplateMgmtEditEmailPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditEmailPage extends TemplateMgmtBasePageDynamic {
   static readonly pageUrlSegment = 'edit-email-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/nhs-app/template-mgmt-create-nhs-app-page.ts
+++ b/tests/test-team/pages/nhs-app/template-mgmt-create-nhs-app-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageNonDynamic } from '../template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtCreateNhsAppPage extends TemplateMgmtBasePage {
+export class TemplateMgmtCreateNhsAppPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'create-nhs-app-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/nhs-app/template-mgmt-edit-nhs-app-page.ts
+++ b/tests/test-team/pages/nhs-app/template-mgmt-edit-nhs-app-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageDynamic } from '../template-mgmt-base-page-dynamic';
 
-export class TemplateMgmtEditNhsAppPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditNhsAppPage extends TemplateMgmtBasePageDynamic {
   static readonly pageUrlSegment = 'edit-nhs-app-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/sms/template-mgmt-create-sms-page.ts
+++ b/tests/test-team/pages/sms/template-mgmt-create-sms-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageNonDynamic } from '../template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtCreateSmsPage extends TemplateMgmtBasePage {
+export class TemplateMgmtCreateSmsPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'create-text-message-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
+++ b/tests/test-team/pages/sms/template-mgmt-edit-sms-page.ts
@@ -1,8 +1,8 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from '../template-mgmt-base-page';
 import { TemplateMgmtMessageFormatting } from '../template-mgmt-message-formatting';
+import { TemplateMgmtBasePageDynamic } from '../template-mgmt-base-page-dynamic';
 
-export class TemplateMgmtEditSmsPage extends TemplateMgmtBasePage {
+export class TemplateMgmtEditSmsPage extends TemplateMgmtBasePageDynamic {
   static readonly pageUrlSegment = 'edit-text-message-template';
 
   public readonly nameInput: Locator;

--- a/tests/test-team/pages/template-mgmt-base-page-dynamic.ts
+++ b/tests/test-team/pages/template-mgmt-base-page-dynamic.ts
@@ -1,0 +1,21 @@
+import { type Page } from '@playwright/test';
+import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+
+export abstract class TemplateMgmtBasePageDynamic extends TemplateMgmtBasePage {
+  static readonly dynamicPage = true;
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async loadPage(templateId: string) {
+    const { appUrlSegment, pageUrlSegment } = this
+      .constructor as typeof TemplateMgmtBasePageDynamic;
+
+    if (!pageUrlSegment) {
+      throw new Error('pageUrlSegment is not defined');
+    }
+
+    await this.navigateTo(`/${appUrlSegment}/${pageUrlSegment}/${templateId}`);
+  }
+}

--- a/tests/test-team/pages/template-mgmt-base-page-non-dynamic.ts
+++ b/tests/test-team/pages/template-mgmt-base-page-non-dynamic.ts
@@ -1,0 +1,21 @@
+import { type Page } from '@playwright/test';
+import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+
+export abstract class TemplateMgmtBasePageNonDynamic extends TemplateMgmtBasePage {
+  static readonly dynamicPage = false;
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async loadPage() {
+    const { appUrlSegment, pageUrlSegment } = this
+      .constructor as typeof TemplateMgmtBasePageNonDynamic;
+
+    if (!pageUrlSegment) {
+      throw new Error('pageUrlSegment is not defined');
+    }
+
+    await this.navigateTo(`/${appUrlSegment}/${pageUrlSegment}`);
+  }
+}

--- a/tests/test-team/pages/template-mgmt-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-base-page.ts
@@ -7,8 +7,6 @@ export abstract class TemplateMgmtBasePage {
 
   static readonly pageUrlSegment: string;
 
-  static readonly dynamicPage: boolean;
-
   readonly notifyBannerLink: Locator;
 
   readonly signInLink: Locator;
@@ -66,7 +64,7 @@ export abstract class TemplateMgmtBasePage {
       .and(page.getByText('Skip to main content'));
   }
 
-  // abstract loadPage(templateId?: string): Promise<void>;
+  abstract loadPage(templateId?: string): Promise<void>;
 
   async navigateTo(url: string) {
     await this.page.goto(url);

--- a/tests/test-team/pages/template-mgmt-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-base-page.ts
@@ -7,6 +7,8 @@ export abstract class TemplateMgmtBasePage {
 
   static readonly pageUrlSegment: string;
 
+  static readonly dynamicPage: boolean;
+
   readonly notifyBannerLink: Locator;
 
   readonly signInLink: Locator;
@@ -64,20 +66,7 @@ export abstract class TemplateMgmtBasePage {
       .and(page.getByText('Skip to main content'));
   }
 
-  async loadPage(templateId?: string) {
-    const { appUrlSegment, pageUrlSegment } = this
-      .constructor as typeof TemplateMgmtBasePage;
-
-    if (!pageUrlSegment) {
-      throw new Error('pageUrlSegment is not defined');
-    }
-
-    await this.navigateTo(
-      templateId
-        ? `/${appUrlSegment}/${pageUrlSegment}/${templateId}`
-        : `/${appUrlSegment}/${pageUrlSegment}`
-    );
-  }
+  // abstract loadPage(templateId?: string): Promise<void>;
 
   async navigateTo(url: string) {
     await this.page.goto(url);

--- a/tests/test-team/pages/template-mgmt-choose-page.ts
+++ b/tests/test-team/pages/template-mgmt-choose-page.ts
@@ -1,7 +1,7 @@
 import { Locator, type Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageNonDynamic } from './template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtChoosePage extends TemplateMgmtBasePage {
+export class TemplateMgmtChoosePage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'choose-a-template-type';
 
   readonly radioButtons: Locator;

--- a/tests/test-team/pages/template-mgmt-copy-page.ts
+++ b/tests/test-team/pages/template-mgmt-copy-page.ts
@@ -1,7 +1,7 @@
 import { Locator, type Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export class TemplateMgmtCopyPage extends TemplateMgmtBasePage {
+export class TemplateMgmtCopyPage extends TemplateMgmtBasePageDynamic {
   static readonly pageUrlSegment = 'copy-template';
 
   readonly radioButtons: Locator;

--- a/tests/test-team/pages/template-mgmt-delete-page.ts
+++ b/tests/test-team/pages/template-mgmt-delete-page.ts
@@ -1,7 +1,7 @@
 import { Locator, type Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export class TemplateMgmtDeletePage extends TemplateMgmtBasePage {
+export class TemplateMgmtDeletePage extends TemplateMgmtBasePageDynamic {
   static readonly pageUrlSegment = 'delete-template';
 
   readonly goBackButton: Locator;

--- a/tests/test-team/pages/template-mgmt-invalid-tempate-page.ts
+++ b/tests/test-team/pages/template-mgmt-invalid-tempate-page.ts
@@ -1,5 +1,5 @@
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageNonDynamic } from './template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtInvalidTemplatePage extends TemplateMgmtBasePage {
+export class TemplateMgmtInvalidTemplatePage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'invalid-template';
 }

--- a/tests/test-team/pages/template-mgmt-manage-templates-page.ts
+++ b/tests/test-team/pages/template-mgmt-manage-templates-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageNonDynamic } from './template-mgmt-base-page-non-dynamic';
 
-export class ManageTemplatesPage extends TemplateMgmtBasePage {
+export class ManageTemplatesPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'manage-templates';
 
   readonly createTemplateButton: Locator;

--- a/tests/test-team/pages/template-mgmt-preview-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-preview-base-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export abstract class TemplateMgmtPreviewBasePage extends TemplateMgmtBasePage {
+export abstract class TemplateMgmtPreviewBasePage extends TemplateMgmtBasePageDynamic {
   readonly backToAllTemplatesLinks: Locator;
 
   constructor(page: Page) {

--- a/tests/test-team/pages/template-mgmt-start-page.ts
+++ b/tests/test-team/pages/template-mgmt-start-page.ts
@@ -1,7 +1,7 @@
 import { Locator, type Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageNonDynamic } from './template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtStartPage extends TemplateMgmtBasePage {
+export class TemplateMgmtStartPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'create-and-submit-templates';
 
   readonly startButton: Locator;

--- a/tests/test-team/pages/template-mgmt-submit-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-submit-base-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export abstract class TemplateMgmtSubmitBasePage extends TemplateMgmtBasePage {
+export abstract class TemplateMgmtSubmitBasePage extends TemplateMgmtBasePageDynamic {
   public readonly submitButton: Locator;
 
   public readonly goBackButton: Locator;

--- a/tests/test-team/pages/template-mgmt-template-submitted-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-template-submitted-base-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export abstract class TemplateMgmtTemplateSubmittedBasePage extends TemplateMgmtBasePage {
+export abstract class TemplateMgmtTemplateSubmittedBasePage extends TemplateMgmtBasePageDynamic {
   public readonly templateIdText: Locator;
 
   public readonly templateNameText: Locator;

--- a/tests/test-team/pages/template-mgmt-view-submitted-base-page.ts
+++ b/tests/test-team/pages/template-mgmt-view-submitted-base-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
+import { TemplateMgmtBasePageDynamic } from './template-mgmt-base-page-dynamic';
 
-export abstract class TemplateMgmtViewSubmitedBasePage extends TemplateMgmtBasePage {
+export abstract class TemplateMgmtViewSubmitedBasePage extends TemplateMgmtBasePageDynamic {
   readonly backToAllTemplatesLinks: Locator;
 
   constructor(page: Page) {

--- a/tests/test-team/pages/templates-mgmt-login-page.ts
+++ b/tests/test-team/pages/templates-mgmt-login-page.ts
@@ -1,11 +1,11 @@
 import { Locator, Page } from '@playwright/test';
-import { TemplateMgmtBasePage } from './template-mgmt-base-page';
 import {
   CognitoAuthHelper,
   type TestUser,
 } from '../helpers/auth/cognito-auth-helper';
+import { TemplateMgmtBasePageNonDynamic } from './template-mgmt-base-page-non-dynamic';
 
-export class TemplateMgmtSignInPage extends TemplateMgmtBasePage {
+export class TemplateMgmtSignInPage extends TemplateMgmtBasePageNonDynamic {
   static readonly pageUrlSegment = 'create-and-submit-templates';
 
   public readonly emailInput: Locator;

--- a/tests/test-team/template-mgmt-component-tests/template-protected-routes.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/template-protected-routes.component.spec.ts
@@ -25,6 +25,7 @@ import { TemplateMgmtEditNhsAppPage } from '../pages/nhs-app/template-mgmt-edit-
 import { TemplateMgmtEditSmsPage } from '../pages/sms/template-mgmt-edit-sms-page';
 import { TemplateMgmtInvalidTemplatePage } from '../pages/template-mgmt-invalid-tempate-page';
 import { TemplateMgmtStartPage } from '../pages/template-mgmt-start-page';
+import { TemplateMgmtBasePageDynamic } from '../pages/template-mgmt-base-page-dynamic';
 
 // Reset storage state for this file to avoid being authenticated
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -101,10 +102,14 @@ test.describe('Protected Routes Tests', () => {
       baseURL,
     }) => {
       const appPage = new PageModel(page);
-      await appPage.loadPage('');
+      const isDynamic = appPage instanceof TemplateMgmtBasePageDynamic;
+
+      await (isDynamic ? appPage.loadPage('template-id') : appPage.loadPage());
 
       const redirectPath = encodeURIComponent(
-        `/${PageModel.appUrlSegment}/${PageModel.pageUrlSegment}`
+        isDynamic
+          ? `/${PageModel.appUrlSegment}/${PageModel.pageUrlSegment}/template-id`
+          : `/${PageModel.appUrlSegment}/${PageModel.pageUrlSegment}`
       );
 
       await expect(page).toHaveURL(`${baseURL}/auth?redirect=${redirectPath}`);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Currently navigating to non-existent pages causes a redirect to login. This PR updates middleware to respond with a 404 if the route isn't recognised. The 404 will be handled by Cloudfront (see PR [adding custom error response](https://github.com/NHSDigital/nhs-notify-web-gateway/pull/51)), serving a global 404 page from the CMS.

The routes are checked using regexes. `String.startsWith` would have less performance cost, but would lead to some slightly inconsistent behaviour:

request: `templates/delete-template/id/doesnt-exist`
with regex -> 404
with simple prefix check (`/delete-template/`) -> redirect to login

Playwright tests updated, because the existing protected route test depended on e.g. `templates/delete-template` redirecting to login, whereas it's now a 404.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
