### PR TITLE
CCM-8430: Edit template heading

### DIFF
--- a/frontend/src/__tests__/components/forms/EmailTemplateForm/EmailTemplateForm.test.tsx
+++ b/frontend/src/__tests__/components/forms/EmailTemplateForm/EmailTemplateForm.test.tsx
@@ -37,7 +37,7 @@ test('renders page with preloaded field values', () => {
   expect(container.asFragment()).toMatchSnapshot();
 });
 
-test('renders page without back link for initial state with id', () => {
+test('renders page without back link for initial state with id - edit mode', () => {
   const container = render(
     <EmailTemplateForm
       initialState={mockDeep<TemplateFormState<EmailTemplate>>({

--- a/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
@@ -1807,7 +1807,7 @@ exports[`renders page with preloaded field values 1`] = `
 </DocumentFragment>
 `;
 
-exports[`renders page without back link for initial state with id 1`] = `
+exports[`renders page without back link for initial state with id - edit mode 1`] = `
 <DocumentFragment>
   <main
     class="nhsuk-main-wrapper"

--- a/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
@@ -1863,7 +1863,7 @@ exports[`renders page without back link for initial state with id 1`] = `
             class="nhsuk-heading-xl"
             data-testid="page-heading"
           >
-            Create email template
+            Edit email template
           </h1>
           <div
             class="border"

--- a/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/EmailTemplateForm/__snapshots__/EmailTemplateForm.test.tsx.snap
@@ -92,132 +92,124 @@ exports[`renders page one error 1`] = `
             Create email template
           </h1>
           <div
-            class="border"
+            class="nhsuk-form-group--error"
           >
-            <div
-              class="nhsuk-form-group--error"
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateName"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateName"
-              >
-                Template name
-              </label>
-              <div
-                class="nhsuk-hint"
-              >
-                This will not be visible to recipients.
-              </div>
-              <details
-                class="nhsuk-details"
-                data-testid="how-to-name-your-template"
-              >
-                <summary
-                  class="nhsuk-details__summary"
-                >
-                  <span
-                    class="nhsuk-details__summary-text"
-                  >
-                    Naming your templates
-                  </span>
-                </summary>
-                <div
-                  class="nhsuk-details__text"
-                >
-                  <p>
-                    You should name your templates in a way that works best for your service or organisation.
-                  </p>
-                  <p>
-                    Common template names include the:
-                  </p>
-                  <ul>
-                    <li>
-                      message channel it uses
-                    </li>
-                    <li>
-                      subject or reason for the message
-                    </li>
-                    <li>
-                      intended audience for the template
-                    </li>
-                    <li>
-                      version number of the template
-                    </li>
-                  </ul>
-                  <p
-                    data-testid="template-name-example"
-                  >
-                    For example, 'Email - covid19 2023 - over 65s - version 3'
-                  </p>
-                </div>
-              </details>
-              <div
-                class="nhsuk-form-group nhsuk-form-group--error"
+              Template name
+            </label>
+            <div
+              class="nhsuk-hint"
+            >
+              This will not be visible to recipients.
+            </div>
+            <details
+              class="nhsuk-details"
+              data-testid="how-to-name-your-template"
+            >
+              <summary
+                class="nhsuk-details__summary"
               >
                 <span
-                  class="nhsuk-error-message"
-                  id="emailTemplateName--error-message"
+                  class="nhsuk-details__summary-text"
                 >
-                  <span
-                    class="nhsuk-u-visually-hidden"
-                  >
-                    Error: 
-                  </span>
-                  Template name error
+                  Naming your templates
                 </span>
-                <input
-                  aria-describedby="emailTemplateName--error-message"
-                  class="nhsuk-input nhsuk-input--error"
-                  data-testid="emailTemplateName-input"
-                  id="emailTemplateName"
-                  name="emailTemplateName"
-                  type="text"
-                  value=""
-                />
+              </summary>
+              <div
+                class="nhsuk-details__text"
+              >
+                <p>
+                  You should name your templates in a way that works best for your service or organisation.
+                </p>
+                <p>
+                  Common template names include the:
+                </p>
+                <ul>
+                  <li>
+                    message channel it uses
+                  </li>
+                  <li>
+                    subject or reason for the message
+                  </li>
+                  <li>
+                    intended audience for the template
+                  </li>
+                  <li>
+                    version number of the template
+                  </li>
+                </ul>
+                <p
+                  data-testid="template-name-example"
+                >
+                  For example, 'Email - covid19 2023 - over 65s - version 3'
+                </p>
               </div>
+            </details>
+            <div
+              class="nhsuk-form-group nhsuk-form-group--error"
+            >
+              <span
+                class="nhsuk-error-message"
+                id="emailTemplateName--error-message"
+              >
+                <span
+                  class="nhsuk-u-visually-hidden"
+                >
+                  Error: 
+                </span>
+                Template name error
+              </span>
+              <input
+                aria-describedby="emailTemplateName--error-message"
+                class="nhsuk-input nhsuk-input--error"
+                data-testid="emailTemplateName-input"
+                id="emailTemplateName"
+                name="emailTemplateName"
+                type="text"
+                value=""
+              />
             </div>
           </div>
-          <div
-            class="border"
-          >
-            <div>
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateSubjectLine"
-              >
-                Subject line
-              </label>
-              <div
-                class="nhsuk-form-group"
-              >
-                <input
-                  class="nhsuk-input"
-                  data-testid="emailTemplateSubjectLine-input"
-                  id="emailTemplateSubjectLine"
-                  name="emailTemplateSubjectLine"
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
+          <div>
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateSubjectLine"
+            >
+              Subject line
+            </label>
             <div
               class="nhsuk-form-group"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateMessage"
-                id="emailTemplateMessage--label"
-              >
-                Message
-              </label>
-              <textarea
-                class="nhsuk-textarea"
-                data-testid="emailTemplateMessage-input"
-                id="emailTemplateMessage"
-                name="emailTemplateMessage"
-                rows="10"
+              <input
+                class="nhsuk-input"
+                data-testid="emailTemplateSubjectLine-input"
+                id="emailTemplateSubjectLine"
+                name="emailTemplateSubjectLine"
+                type="text"
+                value=""
               />
             </div>
+          </div>
+          <div
+            class="nhsuk-form-group"
+          >
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateMessage"
+              id="emailTemplateMessage--label"
+            >
+              Message
+            </label>
+            <textarea
+              class="nhsuk-textarea"
+              data-testid="emailTemplateMessage-input"
+              id="emailTemplateMessage"
+              name="emailTemplateMessage"
+              rows="10"
+            />
           </div>
           <button
             aria-disabled="false"
@@ -712,158 +704,150 @@ exports[`renders page with multiple errors 1`] = `
             Create email template
           </h1>
           <div
-            class="border"
+            class="nhsuk-form-group--error"
           >
-            <div
-              class="nhsuk-form-group--error"
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateName"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateName"
-              >
-                Template name
-              </label>
-              <div
-                class="nhsuk-hint"
-              >
-                This will not be visible to recipients.
-              </div>
-              <details
-                class="nhsuk-details"
-                data-testid="how-to-name-your-template"
-              >
-                <summary
-                  class="nhsuk-details__summary"
-                >
-                  <span
-                    class="nhsuk-details__summary-text"
-                  >
-                    Naming your templates
-                  </span>
-                </summary>
-                <div
-                  class="nhsuk-details__text"
-                >
-                  <p>
-                    You should name your templates in a way that works best for your service or organisation.
-                  </p>
-                  <p>
-                    Common template names include the:
-                  </p>
-                  <ul>
-                    <li>
-                      message channel it uses
-                    </li>
-                    <li>
-                      subject or reason for the message
-                    </li>
-                    <li>
-                      intended audience for the template
-                    </li>
-                    <li>
-                      version number of the template
-                    </li>
-                  </ul>
-                  <p
-                    data-testid="template-name-example"
-                  >
-                    For example, 'Email - covid19 2023 - over 65s - version 3'
-                  </p>
-                </div>
-              </details>
-              <div
-                class="nhsuk-form-group nhsuk-form-group--error"
+              Template name
+            </label>
+            <div
+              class="nhsuk-hint"
+            >
+              This will not be visible to recipients.
+            </div>
+            <details
+              class="nhsuk-details"
+              data-testid="how-to-name-your-template"
+            >
+              <summary
+                class="nhsuk-details__summary"
               >
                 <span
-                  class="nhsuk-error-message"
-                  id="emailTemplateName--error-message"
+                  class="nhsuk-details__summary-text"
                 >
-                  <span
-                    class="nhsuk-u-visually-hidden"
-                  >
-                    Error: 
-                  </span>
-                  Template name error
+                  Naming your templates
                 </span>
-                <input
-                  aria-describedby="emailTemplateName--error-message"
-                  class="nhsuk-input nhsuk-input--error"
-                  data-testid="emailTemplateName-input"
-                  id="emailTemplateName"
-                  name="emailTemplateName"
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="border"
-          >
-            <div
-              class="nhsuk-form-group--error"
-            >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateSubjectLine"
-              >
-                Subject line
-              </label>
+              </summary>
               <div
-                class="nhsuk-form-group nhsuk-form-group--error"
+                class="nhsuk-details__text"
               >
-                <span
-                  class="nhsuk-error-message"
-                  id="emailTemplateSubjectLine--error-message"
+                <p>
+                  You should name your templates in a way that works best for your service or organisation.
+                </p>
+                <p>
+                  Common template names include the:
+                </p>
+                <ul>
+                  <li>
+                    message channel it uses
+                  </li>
+                  <li>
+                    subject or reason for the message
+                  </li>
+                  <li>
+                    intended audience for the template
+                  </li>
+                  <li>
+                    version number of the template
+                  </li>
+                </ul>
+                <p
+                  data-testid="template-name-example"
                 >
-                  <span
-                    class="nhsuk-u-visually-hidden"
-                  >
-                    Error: 
-                  </span>
-                  Template subject line error
-                </span>
-                <input
-                  aria-describedby="emailTemplateSubjectLine--error-message"
-                  class="nhsuk-input nhsuk-input--error"
-                  data-testid="emailTemplateSubjectLine-input"
-                  id="emailTemplateSubjectLine"
-                  name="emailTemplateSubjectLine"
-                  type="text"
-                  value=""
-                />
+                  For example, 'Email - covid19 2023 - over 65s - version 3'
+                </p>
               </div>
-            </div>
+            </details>
             <div
               class="nhsuk-form-group nhsuk-form-group--error"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateMessage"
-                id="emailTemplateMessage--label"
-              >
-                Message
-              </label>
               <span
                 class="nhsuk-error-message"
-                id="emailTemplateMessage--error-message"
+                id="emailTemplateName--error-message"
               >
                 <span
                   class="nhsuk-u-visually-hidden"
                 >
                   Error: 
                 </span>
-                Template message error
+                Template name error
               </span>
-              <textarea
-                aria-describedby="emailTemplateMessage--error-message"
-                class="nhsuk-textarea nhsuk-textarea--error"
-                data-testid="emailTemplateMessage-input"
-                id="emailTemplateMessage"
-                name="emailTemplateMessage"
-                rows="10"
+              <input
+                aria-describedby="emailTemplateName--error-message"
+                class="nhsuk-input nhsuk-input--error"
+                data-testid="emailTemplateName-input"
+                id="emailTemplateName"
+                name="emailTemplateName"
+                type="text"
+                value=""
               />
             </div>
+          </div>
+          <div
+            class="nhsuk-form-group--error"
+          >
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateSubjectLine"
+            >
+              Subject line
+            </label>
+            <div
+              class="nhsuk-form-group nhsuk-form-group--error"
+            >
+              <span
+                class="nhsuk-error-message"
+                id="emailTemplateSubjectLine--error-message"
+              >
+                <span
+                  class="nhsuk-u-visually-hidden"
+                >
+                  Error: 
+                </span>
+                Template subject line error
+              </span>
+              <input
+                aria-describedby="emailTemplateSubjectLine--error-message"
+                class="nhsuk-input nhsuk-input--error"
+                data-testid="emailTemplateSubjectLine-input"
+                id="emailTemplateSubjectLine"
+                name="emailTemplateSubjectLine"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="nhsuk-form-group nhsuk-form-group--error"
+          >
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateMessage"
+              id="emailTemplateMessage--label"
+            >
+              Message
+            </label>
+            <span
+              class="nhsuk-error-message"
+              id="emailTemplateMessage--error-message"
+            >
+              <span
+                class="nhsuk-u-visually-hidden"
+              >
+                Error: 
+              </span>
+              Template message error
+            </span>
+            <textarea
+              aria-describedby="emailTemplateMessage--error-message"
+              class="nhsuk-textarea nhsuk-textarea--error"
+              data-testid="emailTemplateMessage-input"
+              id="emailTemplateMessage"
+              name="emailTemplateMessage"
+              rows="10"
+            />
           </div>
           <button
             aria-disabled="false"
@@ -1318,121 +1302,113 @@ exports[`renders page with preloaded field values 1`] = `
           >
             Create email template
           </h1>
-          <div
-            class="border"
-          >
-            <div>
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateName"
-              >
-                Template name
-              </label>
-              <div
-                class="nhsuk-hint"
-              >
-                This will not be visible to recipients.
-              </div>
-              <details
-                class="nhsuk-details"
-                data-testid="how-to-name-your-template"
-              >
-                <summary
-                  class="nhsuk-details__summary"
-                >
-                  <span
-                    class="nhsuk-details__summary-text"
-                  >
-                    Naming your templates
-                  </span>
-                </summary>
-                <div
-                  class="nhsuk-details__text"
-                >
-                  <p>
-                    You should name your templates in a way that works best for your service or organisation.
-                  </p>
-                  <p>
-                    Common template names include the:
-                  </p>
-                  <ul>
-                    <li>
-                      message channel it uses
-                    </li>
-                    <li>
-                      subject or reason for the message
-                    </li>
-                    <li>
-                      intended audience for the template
-                    </li>
-                    <li>
-                      version number of the template
-                    </li>
-                  </ul>
-                  <p
-                    data-testid="template-name-example"
-                  >
-                    For example, 'Email - covid19 2023 - over 65s - version 3'
-                  </p>
-                </div>
-              </details>
-              <div
-                class="nhsuk-form-group"
-              >
-                <input
-                  class="nhsuk-input"
-                  data-testid="emailTemplateName-input"
-                  id="emailTemplateName"
-                  name="emailTemplateName"
-                  type="text"
-                  value="template-name"
-                />
-              </div>
+          <div>
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateName"
+            >
+              Template name
+            </label>
+            <div
+              class="nhsuk-hint"
+            >
+              This will not be visible to recipients.
             </div>
-          </div>
-          <div
-            class="border"
-          >
-            <div>
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateSubjectLine"
+            <details
+              class="nhsuk-details"
+              data-testid="how-to-name-your-template"
+            >
+              <summary
+                class="nhsuk-details__summary"
               >
-                Subject line
-              </label>
+                <span
+                  class="nhsuk-details__summary-text"
+                >
+                  Naming your templates
+                </span>
+              </summary>
               <div
-                class="nhsuk-form-group"
+                class="nhsuk-details__text"
               >
-                <input
-                  class="nhsuk-input"
-                  data-testid="emailTemplateSubjectLine-input"
-                  id="emailTemplateSubjectLine"
-                  name="emailTemplateSubjectLine"
-                  type="text"
-                  value="template-subject-line"
-                />
+                <p>
+                  You should name your templates in a way that works best for your service or organisation.
+                </p>
+                <p>
+                  Common template names include the:
+                </p>
+                <ul>
+                  <li>
+                    message channel it uses
+                  </li>
+                  <li>
+                    subject or reason for the message
+                  </li>
+                  <li>
+                    intended audience for the template
+                  </li>
+                  <li>
+                    version number of the template
+                  </li>
+                </ul>
+                <p
+                  data-testid="template-name-example"
+                >
+                  For example, 'Email - covid19 2023 - over 65s - version 3'
+                </p>
               </div>
-            </div>
+            </details>
             <div
               class="nhsuk-form-group"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateMessage"
-                id="emailTemplateMessage--label"
-              >
-                Message
-              </label>
-              <textarea
-                class="nhsuk-textarea"
-                data-testid="emailTemplateMessage-input"
-                id="emailTemplateMessage"
-                name="emailTemplateMessage"
-                rows="10"
-              >
-                template-message
-              </textarea>
+              <input
+                class="nhsuk-input"
+                data-testid="emailTemplateName-input"
+                id="emailTemplateName"
+                name="emailTemplateName"
+                type="text"
+                value="template-name"
+              />
             </div>
+          </div>
+          <div>
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateSubjectLine"
+            >
+              Subject line
+            </label>
+            <div
+              class="nhsuk-form-group"
+            >
+              <input
+                class="nhsuk-input"
+                data-testid="emailTemplateSubjectLine-input"
+                id="emailTemplateSubjectLine"
+                name="emailTemplateSubjectLine"
+                type="text"
+                value="template-subject-line"
+              />
+            </div>
+          </div>
+          <div
+            class="nhsuk-form-group"
+          >
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateMessage"
+              id="emailTemplateMessage--label"
+            >
+              Message
+            </label>
+            <textarea
+              class="nhsuk-textarea"
+              data-testid="emailTemplateMessage-input"
+              id="emailTemplateMessage"
+              name="emailTemplateMessage"
+              rows="10"
+            >
+              template-message
+            </textarea>
           </div>
           <button
             aria-disabled="false"
@@ -1865,121 +1841,113 @@ exports[`renders page without back link for initial state with id 1`] = `
           >
             Edit email template
           </h1>
-          <div
-            class="border"
-          >
-            <div>
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateName"
-              >
-                Template name
-              </label>
-              <div
-                class="nhsuk-hint"
-              >
-                This will not be visible to recipients.
-              </div>
-              <details
-                class="nhsuk-details"
-                data-testid="how-to-name-your-template"
-              >
-                <summary
-                  class="nhsuk-details__summary"
-                >
-                  <span
-                    class="nhsuk-details__summary-text"
-                  >
-                    Naming your templates
-                  </span>
-                </summary>
-                <div
-                  class="nhsuk-details__text"
-                >
-                  <p>
-                    You should name your templates in a way that works best for your service or organisation.
-                  </p>
-                  <p>
-                    Common template names include the:
-                  </p>
-                  <ul>
-                    <li>
-                      message channel it uses
-                    </li>
-                    <li>
-                      subject or reason for the message
-                    </li>
-                    <li>
-                      intended audience for the template
-                    </li>
-                    <li>
-                      version number of the template
-                    </li>
-                  </ul>
-                  <p
-                    data-testid="template-name-example"
-                  >
-                    For example, 'Email - covid19 2023 - over 65s - version 3'
-                  </p>
-                </div>
-              </details>
-              <div
-                class="nhsuk-form-group"
-              >
-                <input
-                  class="nhsuk-input"
-                  data-testid="emailTemplateName-input"
-                  id="emailTemplateName"
-                  name="emailTemplateName"
-                  type="text"
-                  value="template-name"
-                />
-              </div>
+          <div>
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateName"
+            >
+              Template name
+            </label>
+            <div
+              class="nhsuk-hint"
+            >
+              This will not be visible to recipients.
             </div>
-          </div>
-          <div
-            class="border"
-          >
-            <div>
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateSubjectLine"
+            <details
+              class="nhsuk-details"
+              data-testid="how-to-name-your-template"
+            >
+              <summary
+                class="nhsuk-details__summary"
               >
-                Subject line
-              </label>
+                <span
+                  class="nhsuk-details__summary-text"
+                >
+                  Naming your templates
+                </span>
+              </summary>
               <div
-                class="nhsuk-form-group"
+                class="nhsuk-details__text"
               >
-                <input
-                  class="nhsuk-input"
-                  data-testid="emailTemplateSubjectLine-input"
-                  id="emailTemplateSubjectLine"
-                  name="emailTemplateSubjectLine"
-                  type="text"
-                  value="template-subject-line"
-                />
+                <p>
+                  You should name your templates in a way that works best for your service or organisation.
+                </p>
+                <p>
+                  Common template names include the:
+                </p>
+                <ul>
+                  <li>
+                    message channel it uses
+                  </li>
+                  <li>
+                    subject or reason for the message
+                  </li>
+                  <li>
+                    intended audience for the template
+                  </li>
+                  <li>
+                    version number of the template
+                  </li>
+                </ul>
+                <p
+                  data-testid="template-name-example"
+                >
+                  For example, 'Email - covid19 2023 - over 65s - version 3'
+                </p>
               </div>
-            </div>
+            </details>
             <div
               class="nhsuk-form-group"
             >
-              <label
-                class="nhsuk-label nhsuk-label--s"
-                for="emailTemplateMessage"
-                id="emailTemplateMessage--label"
-              >
-                Message
-              </label>
-              <textarea
-                class="nhsuk-textarea"
-                data-testid="emailTemplateMessage-input"
-                id="emailTemplateMessage"
-                name="emailTemplateMessage"
-                rows="10"
-              >
-                template-message
-              </textarea>
+              <input
+                class="nhsuk-input"
+                data-testid="emailTemplateName-input"
+                id="emailTemplateName"
+                name="emailTemplateName"
+                type="text"
+                value="template-name"
+              />
             </div>
+          </div>
+          <div>
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateSubjectLine"
+            >
+              Subject line
+            </label>
+            <div
+              class="nhsuk-form-group"
+            >
+              <input
+                class="nhsuk-input"
+                data-testid="emailTemplateSubjectLine-input"
+                id="emailTemplateSubjectLine"
+                name="emailTemplateSubjectLine"
+                type="text"
+                value="template-subject-line"
+              />
+            </div>
+          </div>
+          <div
+            class="nhsuk-form-group"
+          >
+            <label
+              class="nhsuk-label nhsuk-label--s"
+              for="emailTemplateMessage"
+              id="emailTemplateMessage--label"
+            >
+              Message
+            </label>
+            <textarea
+              class="nhsuk-textarea"
+              data-testid="emailTemplateMessage-input"
+              id="emailTemplateMessage"
+              name="emailTemplateMessage"
+              rows="10"
+            >
+              template-message
+            </textarea>
           </div>
           <button
             aria-disabled="false"

--- a/frontend/src/__tests__/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.test.tsx
+++ b/frontend/src/__tests__/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.test.tsx
@@ -64,7 +64,7 @@ test('renders page with preloaded field values', () => {
   expect(container.asFragment()).toMatchSnapshot();
 });
 
-test('renders page without back link for initial state with id', () => {
+test('renders page without back link for initial state with id - edit mode', () => {
   const container = render(
     <NhsAppTemplateForm
       initialState={mockDeep<TemplateFormState<NHSAppTemplate>>({

--- a/frontend/src/__tests__/components/forms/NhsAppTemplateForm/__snapshots__/NhsAppTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/NhsAppTemplateForm/__snapshots__/NhsAppTemplateForm.test.tsx.snap
@@ -1966,7 +1966,7 @@ exports[`renders page without back link for initial state with id 1`] = `
             class="nhsuk-heading-xl"
             data-testid="page-heading"
           >
-            Create NHS App message template
+            Edit NHS App message template
           </h1>
           <div>
             <label

--- a/frontend/src/__tests__/components/forms/NhsAppTemplateForm/__snapshots__/NhsAppTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/NhsAppTemplateForm/__snapshots__/NhsAppTemplateForm.test.tsx.snap
@@ -1934,7 +1934,7 @@ exports[`renders page with preloaded field values 1`] = `
 </DocumentFragment>
 `;
 
-exports[`renders page without back link for initial state with id 1`] = `
+exports[`renders page without back link for initial state with id - edit mode 1`] = `
 <DocumentFragment>
   <main
     class="nhsuk-main-wrapper"

--- a/frontend/src/__tests__/components/forms/SmsTemplateForm/SmsTemplateForm.test.tsx
+++ b/frontend/src/__tests__/components/forms/SmsTemplateForm/SmsTemplateForm.test.tsx
@@ -26,7 +26,7 @@ jest.mock('react', () => {
 jest.mock('@utils/amplify-utils');
 
 describe('CreateSmsTemplate component', () => {
-  test('renders page with back link if initial state has no id', async () => {
+  test('renders page with back link if initial state has no id - edit mode', async () => {
     const container = render(
       <SmsTemplateForm
         initialState={mockDeep<Draft<TemplateFormState<SMSTemplate>>>({

--- a/frontend/src/__tests__/components/forms/SmsTemplateForm/__snapshots__/SmsTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/SmsTemplateForm/__snapshots__/SmsTemplateForm.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`CreateSmsTemplate component renders page one error 1`] = `
         <h1
           data-testid="page-heading"
         >
-          Create text message template
+          Edit text message template
         </h1>
         <form
           action="/action"
@@ -760,7 +760,7 @@ exports[`CreateSmsTemplate component renders page with multiple errors 1`] = `
         <h1
           data-testid="page-heading"
         >
-          Create text message template
+          Edit text message template
         </h1>
         <form
           action="/action"
@@ -1109,7 +1109,7 @@ exports[`CreateSmsTemplate component renders page with no back link if initial s
         <h1
           data-testid="page-heading"
         >
-          Create text message template
+          Edit text message template
         </h1>
         <form
           action="/action"

--- a/frontend/src/__tests__/components/forms/SmsTemplateForm/__snapshots__/SmsTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/SmsTemplateForm/__snapshots__/SmsTemplateForm.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`CreateSmsTemplate component renders page one error 1`] = `
 </DocumentFragment>
 `;
 
-exports[`CreateSmsTemplate component renders page with back link if initial state has no id 1`] = `
+exports[`CreateSmsTemplate component renders page with back link if initial state has no id - edit mode 1`] = `
 <DocumentFragment>
   <div
     class="nhsuk-back-link"

--- a/frontend/src/__tests__/components/molecules/Footer.test.tsx
+++ b/frontend/src/__tests__/components/molecules/Footer.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { NHSNotifyFooter } from '@molecules/Footer/Footer';
 import content from '@content/content';
 
-const footerContent = content.components.footerComponent;
+const footerContent = content.components.footer;
 
 describe('Footer component', () => {
   it('renders component correctly', () => {

--- a/frontend/src/__tests__/components/molecules/TemplateNameGuidance.test.tsx
+++ b/frontend/src/__tests__/components/molecules/TemplateNameGuidance.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { TemplateNameGuidance } from '@molecules/TemplateNameGuidance';
 import { TemplateType } from 'nhs-notify-web-template-management-utils';
-import { nameYourTemplateContent } from '@content/content';
+import content from '@content/content';
 
 describe('TemplateNameGuidance component', () => {
   const templateTypes = Object.keys(TemplateType);
@@ -19,7 +19,9 @@ describe('TemplateNameGuidance component', () => {
     (templateType: string) => {
       const templateTypeToUse = templateType as TemplateType;
       const expectedText =
-        nameYourTemplateContent.templateNameDetailsExample[templateTypeToUse];
+        content.components.nameYourTemplate.templateNameDetailsExample[
+          templateTypeToUse
+        ];
 
       const container = render(
         <TemplateNameGuidance template={templateTypeToUse} />

--- a/frontend/src/components/forms/ChooseTemplate/ChooseTemplate.tsx
+++ b/frontend/src/components/forms/ChooseTemplate/ChooseTemplate.tsx
@@ -5,7 +5,7 @@ import { BackLink } from 'nhsuk-react-components';
 import { NHSNotifyRadioButtonForm } from '@molecules/NHSNotifyRadioButtonForm/NHSNotifyRadioButtonForm';
 import { ZodErrorSummary } from '@molecules/ZodErrorSummary/ZodErrorSummary';
 import { getBasePath } from '@utils/get-base-path';
-import { chooseTemplatePageContent } from '@content/content';
+import content from '@content/content';
 import {
   TemplateType,
   templateTypeDisplayMappings,
@@ -33,7 +33,7 @@ export const ChooseTemplate = ({
     learnMoreLink,
     learnMoreText,
     backLinkText,
-  } = chooseTemplatePageContent;
+  } = content.components.chooseTemplate;
 
   return (
     <>

--- a/frontend/src/components/forms/CopyTemplate/CopyTemplate.tsx
+++ b/frontend/src/components/forms/CopyTemplate/CopyTemplate.tsx
@@ -4,7 +4,7 @@ import { useActionState } from 'react';
 import { BackLink } from 'nhsuk-react-components';
 import { NHSNotifyRadioButtonForm } from '@molecules/NHSNotifyRadioButtonForm/NHSNotifyRadioButtonForm';
 import { ZodErrorSummary } from '@molecules/ZodErrorSummary/ZodErrorSummary';
-import { copyTemplatePageContent } from '@content/content';
+import content from '@content/content';
 import {
   Template,
   TemplateType,
@@ -37,7 +37,7 @@ export const CopyTemplate = ({ template }: CopyTemplate) => {
     pageHeading,
     radiosLabel,
     backLinkText,
-  } = copyTemplatePageContent;
+  } = content.components.copyTemplate;
 
   const fullPageHeading = `${pageHeading} '${template.name}'`;
 

--- a/frontend/src/components/forms/DeleteTemplate/DeleteTemplate.tsx
+++ b/frontend/src/components/forms/DeleteTemplate/DeleteTemplate.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useActionState } from 'react';
 import { ChannelTemplate } from 'nhs-notify-web-template-management-utils';
-import { deleteTemplatePageContent } from '@content/content';
+import content from '@content/content';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
 import { NHSNotifyFormWrapper } from '@molecules/NHSNotifyFormWrapper/NHSNotifyFormWrapper';
 import { NHSNotifyButton } from '@atoms/NHSNotifyButton/NHSNotifyButton';
@@ -17,7 +17,7 @@ type DeleteTemplateProps = {
 
 export const DeleteTemplate: FC<DeleteTemplateProps> = ({ template }) => {
   const { pageHeading, hintText, noButtonText, yesButtonText } =
-    deleteTemplatePageContent;
+    content.components.deleteTemplate;
 
   const [yesState, yesAction] = useActionState(
     deleteTemplateYesAction,

--- a/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
@@ -32,7 +32,7 @@ export const EmailTemplateForm: FC<
   PageComponentProps<EmailTemplate | Draft<EmailTemplate>>
 > = ({ initialState }) => {
   const {
-    pageHeading,
+    pageHeadingSuffix,
     errorHeading,
     buttonText,
     templateNameLabelText,
@@ -62,9 +62,11 @@ export const EmailTemplateForm: FC<
   const templateMessageError =
     state.validationError?.fieldErrors.emailTemplateMessage?.join(', ');
 
+  const editMode = 'id' in initialState;
+
   return (
     <>
-      {'id' in initialState ? null : (
+      {editMode ? null : (
         <BackLink href={`${getBasePath()}/choose-a-template-type`}>
           {backLinkText}
         </BackLink>
@@ -78,7 +80,8 @@ export const EmailTemplateForm: FC<
               formId='create-email-template'
             >
               <h1 className='nhsuk-heading-xl' data-testid='page-heading'>
-                {pageHeading}
+                {editMode ? 'Edit ' : 'Create '}
+                {pageHeadingSuffix}
               </h1>
 
               <FormSection>

--- a/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
@@ -22,7 +22,6 @@ import {
   TemplateType,
 } from 'nhs-notify-web-template-management-utils';
 import content from '@content/content';
-import { FormSection } from '@molecules/FormSection/FormSection';
 import { useTextInput } from '@hooks/use-text-input.hook';
 import { ChannelGuidance } from '@molecules/ChannelGuidance/ChannelGuidance';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';

--- a/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
@@ -21,7 +21,7 @@ import {
   PageComponentProps,
   TemplateType,
 } from 'nhs-notify-web-template-management-utils';
-import { createEmailTemplatePageContent } from '@content/content';
+import content from '@content/content';
 import { FormSection } from '@molecules/FormSection/FormSection';
 import { useTextInput } from '@hooks/use-text-input.hook';
 import { ChannelGuidance } from '@molecules/ChannelGuidance/ChannelGuidance';
@@ -40,7 +40,7 @@ export const EmailTemplateForm: FC<
     templateMessageLabelText,
     templateNameHintText,
     backLinkText,
-  } = createEmailTemplatePageContent;
+  } = content.components.templateFormEmail;
 
   const [state, action] = useActionState(processFormActions, initialState);
 

--- a/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/frontend/src/components/forms/EmailTemplateForm/EmailTemplateForm.tsx
@@ -83,58 +83,51 @@ export const EmailTemplateForm: FC<
                 {editMode ? 'Edit ' : 'Create '}
                 {pageHeadingSuffix}
               </h1>
-
-              <FormSection>
-                <div className={templateNameError && 'nhsuk-form-group--error'}>
-                  <Label htmlFor='emailTemplateName' size='s'>
-                    {templateNameLabelText}
-                  </Label>
-                  <HintText>{templateNameHintText}</HintText>
-                  <TemplateNameGuidance template={TemplateType.EMAIL} />
-                  <TextInput
-                    id='emailTemplateName'
-                    onChange={emailTemplateNameHandler}
-                    value={emailTemplateName}
-                    error={templateNameError}
-                    errorProps={{ id: 'emailTemplateName--error-message' }}
-                    data-testid='emailTemplateName-input'
-                  />
-                </div>
-              </FormSection>
-
-              <FormSection>
-                <div
-                  className={
-                    templateSubjectLineError && 'nhsuk-form-group--error'
-                  }
-                >
-                  <Label htmlFor='emailTemplateSubjectLine' size='s'>
-                    {templateSubjectLineLabelText}
-                  </Label>
-                  <TextInput
-                    id='emailTemplateSubjectLine'
-                    onChange={emailTemplateSubjectLineHandler}
-                    value={emailTemplateSubjectLine}
-                    error={templateSubjectLineError}
-                    errorProps={{
-                      id: 'emailTemplateSubjectLine--error-message',
-                    }}
-                    data-testid='emailTemplateSubjectLine-input'
-                  />
-                </div>
-
-                <Textarea
-                  label={templateMessageLabelText}
-                  labelProps={{ size: 's' }}
-                  id='emailTemplateMessage'
-                  rows={10}
-                  onChange={emailTemplateMessageHandler}
-                  value={emailTemplateMessage}
-                  error={templateMessageError}
-                  errorProps={{ id: 'emailTemplateMessage--error-message' }}
-                  data-testid='emailTemplateMessage-input'
+              <div className={templateNameError && 'nhsuk-form-group--error'}>
+                <Label htmlFor='emailTemplateName' size='s'>
+                  {templateNameLabelText}
+                </Label>
+                <HintText>{templateNameHintText}</HintText>
+                <TemplateNameGuidance template={TemplateType.EMAIL} />
+                <TextInput
+                  id='emailTemplateName'
+                  onChange={emailTemplateNameHandler}
+                  value={emailTemplateName}
+                  error={templateNameError}
+                  errorProps={{ id: 'emailTemplateName--error-message' }}
+                  data-testid='emailTemplateName-input'
                 />
-              </FormSection>
+              </div>
+              <div
+                className={
+                  templateSubjectLineError && 'nhsuk-form-group--error'
+                }
+              >
+                <Label htmlFor='emailTemplateSubjectLine' size='s'>
+                  {templateSubjectLineLabelText}
+                </Label>
+                <TextInput
+                  id='emailTemplateSubjectLine'
+                  onChange={emailTemplateSubjectLineHandler}
+                  value={emailTemplateSubjectLine}
+                  error={templateSubjectLineError}
+                  errorProps={{
+                    id: 'emailTemplateSubjectLine--error-message',
+                  }}
+                  data-testid='emailTemplateSubjectLine-input'
+                />
+              </div>
+              <Textarea
+                label={templateMessageLabelText}
+                labelProps={{ size: 's' }}
+                id='emailTemplateMessage'
+                rows={10}
+                onChange={emailTemplateMessageHandler}
+                value={emailTemplateMessage}
+                error={templateMessageError}
+                errorProps={{ id: 'emailTemplateMessage--error-message' }}
+                data-testid='emailTemplateMessage-input'
+              />
               <NHSNotifyButton
                 type='submit'
                 id='create-email-template-submit-button'

--- a/frontend/src/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.tsx
+++ b/frontend/src/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.tsx
@@ -32,7 +32,7 @@ export const NhsAppTemplateForm: FC<
   PageComponentProps<NHSAppTemplate | Draft<NHSAppTemplate>>
 > = ({ initialState }) => {
   const {
-    pageHeading,
+    pageHeadingSuffix,
     errorHeading,
     buttonText,
     characterCountText,
@@ -55,9 +55,11 @@ export const NhsAppTemplateForm: FC<
   const templateMessageError =
     state.validationError?.fieldErrors.nhsAppTemplateMessage?.join(', ');
 
+  const editMode = 'id' in initialState;
+
   return (
     <>
-      {'id' in initialState ? null : (
+      {editMode ? null : (
         <BackLink href={`${getBasePath()}/choose-a-template-type`}>
           {backLinkText}
         </BackLink>
@@ -71,7 +73,8 @@ export const NhsAppTemplateForm: FC<
               formId='create-nhs-app-template'
             >
               <h1 className='nhsuk-heading-xl' data-testid='page-heading'>
-                {pageHeading}
+                {editMode ? 'Edit ' : 'Create '}
+                {pageHeadingSuffix}
               </h1>
               <div className={templateNameError && 'nhsuk-form-group--error'}>
                 <Label htmlFor='nhsAppTemplateName' size='s'>

--- a/frontend/src/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.tsx
+++ b/frontend/src/components/forms/NhsAppTemplateForm/NhsAppTemplateForm.tsx
@@ -21,7 +21,7 @@ import {
   PageComponentProps,
   TemplateType,
 } from 'nhs-notify-web-template-management-utils';
-import { createNhsAppTemplatePageContent } from '@content/content';
+import content from '@content/content';
 import { useTextInput } from '@hooks/use-text-input.hook';
 import { JsEnabled } from '@hooks/js-enabled/JsEnabled';
 import { ChannelGuidance } from '@molecules/ChannelGuidance/ChannelGuidance';
@@ -40,7 +40,8 @@ export const NhsAppTemplateForm: FC<
     templateMessageLabelText,
     templateNameHintText,
     backLinkText,
-  } = createNhsAppTemplatePageContent;
+  } = content.components.templateFormNhsApp;
+
   const [state, action] = useActionState(processFormActions, initialState);
 
   const [nhsAppTemplateMessage, nhsAppMessageHandler] =

--- a/frontend/src/components/forms/ReviewEmailTemplate/ReviewEmailTemplate.tsx
+++ b/frontend/src/components/forms/ReviewEmailTemplate/ReviewEmailTemplate.tsx
@@ -23,7 +23,7 @@ export function ReviewEmailTemplate({
 
   const {
     components: {
-      reviewEmailTemplateContent: { sectionHeading, form },
+      reviewEmailTemplate: { sectionHeading, form },
     },
   } = content;
 

--- a/frontend/src/components/forms/ReviewEmailTemplate/ReviewEmailTemplate.tsx
+++ b/frontend/src/components/forms/ReviewEmailTemplate/ReviewEmailTemplate.tsx
@@ -21,11 +21,7 @@ export function ReviewEmailTemplate({
 }: Readonly<PageComponentProps<EmailTemplate>>) {
   const searchParams = useSearchParams();
 
-  const {
-    components: {
-      reviewEmailTemplate: { sectionHeading, form },
-    },
-  } = content;
+  const { form, sectionHeading } = content.components.reviewEmailTemplate;
 
   const [state, action] = useActionState(
     reviewEmailTemplateAction,

--- a/frontend/src/components/forms/ReviewNHSAppTemplate/ReviewNHSAppTemplate.tsx
+++ b/frontend/src/components/forms/ReviewNHSAppTemplate/ReviewNHSAppTemplate.tsx
@@ -32,7 +32,7 @@ export function ReviewNHSAppTemplate({
 
   const {
     components: {
-      reviewNHSAppTemplateContent: { sectionHeading, form },
+      reviewNHSAppTemplate: { sectionHeading, form },
     },
   } = content;
 

--- a/frontend/src/components/forms/ReviewNHSAppTemplate/ReviewNHSAppTemplate.tsx
+++ b/frontend/src/components/forms/ReviewNHSAppTemplate/ReviewNHSAppTemplate.tsx
@@ -30,11 +30,7 @@ export function ReviewNHSAppTemplate({
   const html = renderNHSAppMarkdown(message);
   const isFromEditPage = searchParams.get('from') === 'edit';
 
-  const {
-    components: {
-      reviewNHSAppTemplate: { sectionHeading, form },
-    },
-  } = content;
+  const { sectionHeading, form } = content.components.reviewNHSAppTemplate;
 
   return (
     <>

--- a/frontend/src/components/forms/ReviewSMSTemplate/ReviewSMSTemplate.tsx
+++ b/frontend/src/components/forms/ReviewSMSTemplate/ReviewSMSTemplate.tsx
@@ -21,11 +21,7 @@ export function ReviewSMSTemplate({
 }: Readonly<PageComponentProps<SMSTemplate>>) {
   const searchParams = useSearchParams();
 
-  const {
-    components: {
-      reviewSMSTemplate: { sectionHeading, form },
-    },
-  } = content;
+  const { sectionHeading, form } = content.components.reviewSMSTemplate;
 
   const [state, action] = useActionState(reviewSmsTemplateAction, initialState);
   const templateMessage = initialState.message;

--- a/frontend/src/components/forms/ReviewSMSTemplate/ReviewSMSTemplate.tsx
+++ b/frontend/src/components/forms/ReviewSMSTemplate/ReviewSMSTemplate.tsx
@@ -23,7 +23,7 @@ export function ReviewSMSTemplate({
 
   const {
     components: {
-      reviewSMSTemplateContent: { sectionHeading, form },
+      reviewSMSTemplate: { sectionHeading, form },
     },
   } = content;
 

--- a/frontend/src/components/forms/SmsTemplateForm/SmsTemplateForm.tsx
+++ b/frontend/src/components/forms/SmsTemplateForm/SmsTemplateForm.tsx
@@ -49,30 +49,41 @@ export const SmsTemplateForm: FC<
 
   const editMode = 'id' in initialState;
 
+  const {
+    backLinkText,
+    buttonText,
+    errorHeading,
+    pageHeadingSuffix,
+    smsCountText1,
+    smsCountText2,
+    smsPricingLink,
+    smsPricingText,
+    templateMessageLabelText,
+    templateNameHintText,
+    templateNameLabelText,
+  } = content.components.templateFormSms;
+
   return (
     <>
       {editMode ? null : (
         <BackLink href={`${getBasePath()}/choose-a-template-type`}>
-          {content.backLinkText}
+          {backLinkText}
         </BackLink>
       )}
       <NHSNotifyMain>
         <div className='nhsuk-grid-row'>
           <div className='nhsuk-grid-column-two-thirds'>
-            <ZodErrorSummary
-              errorHeading={content.errorHeading}
-              state={state}
-            />
+            <ZodErrorSummary errorHeading={errorHeading} state={state} />
             <h1 data-testid='page-heading'>
               {editMode ? 'Edit ' : 'Create '}
-              {content.pageHeadingSuffix}
+              {pageHeadingSuffix}
             </h1>
             <NHSNotifyFormWrapper action={action} formId='create-sms-template'>
               <div className={templateNameError && 'nhsuk-form-group--error'}>
                 <Label htmlFor='smsTemplateName' size='s'>
-                  {content.templateNameLabelText}
+                  {templateNameLabelText}
                 </Label>
-                <HintText>{content.templateNameHintText}</HintText>
+                <HintText>{templateNameHintText}</HintText>
                 <TemplateNameGuidance template='SMS' />
                 <TextInput
                   id='smsTemplateName'
@@ -84,7 +95,7 @@ export const SmsTemplateForm: FC<
               </div>
               <Textarea
                 id='smsTemplateMessage'
-                label={content.templateMessageLabelText}
+                label={templateMessageLabelText}
                 labelProps={{ size: 's' }}
                 defaultValue={smsTemplateMessage}
                 onChange={smsTemplateMessageHandler}
@@ -98,25 +109,25 @@ export const SmsTemplateForm: FC<
                   {smsTemplateMessage.length} characters
                 </p>
                 <p>
-                  {content.smsCountText1}
+                  {smsCountText1}
                   {calculateHowManySmsMessages(
                     Number(smsTemplateMessage.length)
                   )}
-                  {content.smsCountText2}
+                  {smsCountText2}
                 </p>
               </JsEnabled>
               <p>
                 <a
-                  href={content.smsPricingLink}
+                  href={smsPricingLink}
                   data-testid='sms-pricing-link'
                   target='_blank'
                   rel='noopener noreferrer'
                 >
-                  {content.smsPricingText}
+                  {smsPricingText}
                 </a>
               </p>
               <NHSNotifyButton id='create-sms-template-submit-button'>
-                {content.buttonText}
+                {buttonText}
               </NHSNotifyButton>
             </NHSNotifyFormWrapper>
           </div>

--- a/frontend/src/components/forms/SmsTemplateForm/SmsTemplateForm.tsx
+++ b/frontend/src/components/forms/SmsTemplateForm/SmsTemplateForm.tsx
@@ -22,7 +22,7 @@ import {
 import { FC, useActionState } from 'react';
 import { ZodErrorSummary } from '@molecules/ZodErrorSummary/ZodErrorSummary';
 import { TemplateNameGuidance } from '@molecules/TemplateNameGuidance';
-import { createSmsTemplatePageContent as content } from '@content/content';
+import content from '@content/content';
 import { MAX_SMS_CHARACTER_LENGTH } from '@utils/constants';
 import { ChannelGuidance } from '@molecules/ChannelGuidance/ChannelGuidance';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
@@ -47,9 +47,11 @@ export const SmsTemplateForm: FC<
   const templateMessageError =
     state.validationError?.fieldErrors.smsTemplateMessage?.join(', ');
 
+  const editMode = 'id' in initialState;
+
   return (
     <>
-      {'id' in initialState ? null : (
+      {editMode ? null : (
         <BackLink href={`${getBasePath()}/choose-a-template-type`}>
           {content.backLinkText}
         </BackLink>
@@ -61,7 +63,10 @@ export const SmsTemplateForm: FC<
               errorHeading={content.errorHeading}
               state={state}
             />
-            <h1 data-testid='page-heading'>{content.pageHeading}</h1>
+            <h1 data-testid='page-heading'>
+              {editMode ? 'Edit ' : 'Create '}
+              {content.pageHeadingSuffix}
+            </h1>
             <NHSNotifyFormWrapper action={action} formId='create-sms-template'>
               <div className={templateNameError && 'nhsuk-form-group--error'}>
                 <Label htmlFor='smsTemplateName' size='s'>

--- a/frontend/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
+++ b/frontend/src/components/forms/SubmitTemplate/SubmitTemplate.tsx
@@ -3,7 +3,7 @@
 import { FC, useActionState } from 'react';
 import { WarningCallout } from 'nhsuk-react-components';
 import { SubmitTemplatePageComponentProps } from 'nhs-notify-web-template-management-utils';
-import { submitTemplateContent } from '@content/content';
+import content from '@content/content';
 import { NHSNotifyFormWrapper } from '@molecules/NHSNotifyFormWrapper/NHSNotifyFormWrapper';
 import { getBasePath } from '@utils/get-base-path';
 import { submitTemplate } from '@forms/SubmitTemplate/server-action';
@@ -26,7 +26,7 @@ export const SubmitTemplate: FC<SubmitTemplatePageComponentProps> = ({
     submitChecklistParagraphs,
     goBackButtonText,
     buttonText,
-  } = submitTemplateContent;
+  } = content.components.submitTemplate;
 
   const [_, action] = useActionState(submitTemplate, submitPath);
 

--- a/frontend/src/components/molecules/404/404.tsx
+++ b/frontend/src/components/molecules/404/404.tsx
@@ -4,30 +4,26 @@ import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
 import content from '@content/content';
 import Link from 'next/link';
 
-const { error404PageContent } = content.pages;
+const { error404 } = content.pages;
 
 export const ErrorPage404 = () => {
   return (
     <NHSNotifyMain>
       <div className='nhsuk-grid-row' data-testid='page-content-wrapper'>
         <h1 className='nhsuk-heading-xl' data-testid='page-heading'>
-          {error404PageContent.pageHeading}
+          {error404.pageHeading}
         </h1>
 
         <p>
-          {error404PageContent.p1}
-          <Link href={error404PageContent.backLink.path}>
-            {error404PageContent.backLink.text}
-          </Link>
+          {error404.p1}
+          <Link href={error404.backLink.path}>{error404.backLink.text}</Link>
         </p>
-        <p>{error404PageContent.p2}</p>
+        <p>{error404.p2}</p>
 
-        <h2 className='nhsuk-heading-m'>
-          {error404PageContent.contact1.header}
-        </h2>
+        <h2 className='nhsuk-heading-m'>{error404.contact1.header}</h2>
         <p>
-          <Link href={error404PageContent.contact1.href}>
-            {error404PageContent.contact1.contactDetail}
+          <Link href={error404.contact1.href}>
+            {error404.contact1.contactDetail}
           </Link>
         </p>
       </div>

--- a/frontend/src/components/molecules/AuthLink/AuthLink.tsx
+++ b/frontend/src/components/molecules/AuthLink/AuthLink.tsx
@@ -9,11 +9,11 @@ export const AuthLink = () => {
   const { authStatus } = useAuthenticator((ctx) => [ctx.authStatus]);
 
   let id = 'sign-in-link';
-  let linkContent = content.components.headerComponent.links.signIn;
+  let linkContent = content.components.header.links.signIn;
 
   if (authStatus === 'authenticated') {
     id = 'sign-out-link';
-    linkContent = content.components.headerComponent.links.signOut;
+    linkContent = content.components.header.links.signOut;
   }
 
   return (

--- a/frontend/src/components/molecules/ChannelGuidance/ChannelGuidance.tsx
+++ b/frontend/src/components/molecules/ChannelGuidance/ChannelGuidance.tsx
@@ -1,20 +1,19 @@
 import { TemplateType } from 'nhs-notify-web-template-management-utils';
-import { channelGuidanceContent } from '@content/content';
 import styles from './ChannelGuidance.module.scss';
+import content from '@content/content';
 
 export type ChannelGuidanceType = {
   template: TemplateType;
 };
 
 export function ChannelGuidance({ template }: ChannelGuidanceType) {
+  const { channelGuidance } = content.components;
+
   return (
     <>
-      <h2 className='nhsuk-heading-m'>
-        {channelGuidanceContent[template].heading}
-      </h2>
-
+      <h2 className='nhsuk-heading-m'>{channelGuidance[template].heading}</h2>
       <ul className={styles['channel-guidance__list']}>
-        {channelGuidanceContent[template].guidanceLinks.map((guidanceLink) => (
+        {channelGuidance[template].guidanceLinks.map((guidanceLink) => (
           <li className='nhsuk-u-margin-bottom-3' key={guidanceLink.text}>
             <a
               href={guidanceLink.link}

--- a/frontend/src/components/molecules/Footer/Footer.tsx
+++ b/frontend/src/components/molecules/Footer/Footer.tsx
@@ -5,7 +5,7 @@
 import Link from 'next/link';
 import content from '@content/content';
 
-const footerContent = content.components.footerComponent;
+const footerContent = content.components.footer;
 
 export function NHSNotifyFooter() {
   return (

--- a/frontend/src/components/molecules/Header/Header.tsx
+++ b/frontend/src/components/molecules/Header/Header.tsx
@@ -44,7 +44,7 @@ export function NHSNotifyHeader({ dataTestId }: HeaderType) {
               />
             </svg>
             <span className='nhsuk-header__service-name'>
-              {content.components.headerComponent.serviceName}
+              {content.components.header.serviceName}
             </span>
           </Link>
         </div>

--- a/frontend/src/components/molecules/LogoutWarningModal/LogoutWarningModal.tsx
+++ b/frontend/src/components/molecules/LogoutWarningModal/LogoutWarningModal.tsx
@@ -23,12 +23,8 @@ export const LogoutWarningModal = ({
   promptBeforeLogoutSeconds: number;
   logoutInSeconds: number;
 }) => {
-  const {
-    headerComponent: {
-      links: { signOut },
-    },
-    logoutWarningComponent,
-  } = content.components;
+  const { signOut } = content.components.header.links;
+  const { logoutWarning } = content.components;
 
   const initialTime = formatTime(promptBeforeLogoutSeconds);
 
@@ -86,10 +82,10 @@ export const LogoutWarningModal = ({
   return (
     <Modal showModal={showModal}>
       <Modal.Header>
-        {`${logoutWarningComponent.heading} ${remainingTime}.`}
+        {`${logoutWarning.heading} ${remainingTime}.`}
       </Modal.Header>
       <Modal.Body>
-        <p>{logoutWarningComponent.body}</p>
+        <p>{logoutWarning.body}</p>
       </Modal.Body>
       <Modal.Footer>
         <Button
@@ -97,7 +93,7 @@ export const LogoutWarningModal = ({
           onClick={stillHere}
           data-testid='modal-sign-in'
         >
-          {logoutWarningComponent.signIn}
+          {logoutWarning.signIn}
         </Button>
         <div className={styles.signOut}>
           <a

--- a/frontend/src/components/molecules/MessageFormatting/MessageFormatting.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/MessageFormatting.tsx
@@ -12,7 +12,7 @@ import {
 } from './formats';
 import { JSX } from 'react';
 
-const messageFormattingContent = content.components.messageFormattingComponent;
+const messageFormattingContent = content.components.messageFormatting;
 
 const messageFormattingMap: Record<TemplateType, JSX.Element[]> = {
   [TemplateType.NHS_APP]: [

--- a/frontend/src/components/molecules/MessageFormatting/formats/BoldText.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/BoldText.tsx
@@ -1,7 +1,7 @@
 import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 
-const { boldText } = content.components.messageFormattingComponent;
+const { boldText } = content.components.messageFormatting;
 
 export const BoldText = () => (
   <Details data-testid='bold-text-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/BulletList.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/BulletList.tsx
@@ -2,7 +2,7 @@ import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 import styles from '../MessageFormatting.module.scss';
 
-const { bulletLists } = content.components.messageFormattingComponent;
+const { bulletLists } = content.components.messageFormatting;
 
 export const BulletList = () => (
   <Details data-testid='bullet-lists-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/Headings.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/Headings.tsx
@@ -1,7 +1,7 @@
 import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 
-const { headings } = content.components.messageFormattingComponent;
+const { headings } = content.components.messageFormatting;
 
 export const Headings = () => (
   <Details data-testid='headings-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/HorizontalRule.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/HorizontalRule.tsx
@@ -2,7 +2,7 @@ import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 import styles from '../MessageFormatting.module.scss';
 
-const { horizontalLine } = content.components.messageFormattingComponent;
+const { horizontalLine } = content.components.messageFormatting;
 
 export const HorizontalRule = () => (
   <Details data-testid='horizontal-lines-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/LineBreaksAndParagraphs.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/LineBreaksAndParagraphs.tsx
@@ -2,8 +2,7 @@ import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 import styles from '../MessageFormatting.module.scss';
 
-const { lineBreaksAndParagraphs } =
-  content.components.messageFormattingComponent;
+const { lineBreaksAndParagraphs } = content.components.messageFormatting;
 
 export const LineBreaksAndParagraphs = () => (
   <Details data-testid='lines-breaks-and-paragraphs-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/LinksAndUrls.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/LinksAndUrls.tsx
@@ -2,7 +2,7 @@ import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 import { JSX } from 'react';
 
-const { linksAndUrls } = content.components.messageFormattingComponent;
+const { linksAndUrls } = content.components.messageFormatting;
 
 const LinksAndUrls = ({ children }: { children?: JSX.Element }) => (
   <Details data-testid='link-and-url-details'>

--- a/frontend/src/components/molecules/MessageFormatting/formats/NumberedList.tsx
+++ b/frontend/src/components/molecules/MessageFormatting/formats/NumberedList.tsx
@@ -2,7 +2,7 @@ import { Details } from 'nhsuk-react-components';
 import content from '@content/content';
 import styles from '../MessageFormatting.module.scss';
 
-const { numberedLists } = content.components.messageFormattingComponent;
+const { numberedLists } = content.components.messageFormatting;
 
 export const NumberedList = () => (
   <Details data-testid='numbered-list-details'>

--- a/frontend/src/components/molecules/Personalisation/Personalisation.tsx
+++ b/frontend/src/components/molecules/Personalisation/Personalisation.tsx
@@ -1,7 +1,7 @@
 import content from '@content/content';
 import { Details } from 'nhsuk-react-components';
 
-const personalisationContent = content.components.personalisationComponent;
+const personalisationContent = content.components.personalisation;
 
 export function Personalisation() {
   return (

--- a/frontend/src/components/molecules/TemplateNameGuidance/TemplateNameGuidance.tsx
+++ b/frontend/src/components/molecules/TemplateNameGuidance/TemplateNameGuidance.tsx
@@ -1,4 +1,4 @@
-import { nameYourTemplateContent } from '@content/content';
+import content from '@content/content';
 import { Details } from 'nhsuk-react-components';
 import { TemplateNameGuidanceType } from './template-name-guidance.types';
 
@@ -9,7 +9,7 @@ export function TemplateNameGuidance({ template }: TemplateNameGuidanceType) {
     templateNameDetailsListHeader,
     templateNameDetailsList,
     templateNameDetailsExample,
-  } = nameYourTemplateContent;
+  } = content.components.nameYourTemplate;
 
   const templateNameDetailsExampleText = templateNameDetailsExample[template];
 

--- a/frontend/src/components/molecules/TemplateSubmitted/TemplateSubmitted.tsx
+++ b/frontend/src/components/molecules/TemplateSubmitted/TemplateSubmitted.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
-import { templateSubmittedPageContent } from '@content/content';
+import content from '@content/content';
 
 type TemplateSubmittedProps = {
   templateId: string;
@@ -12,6 +12,7 @@ export const TemplateSubmitted = ({
   templateName,
 }: TemplateSubmittedProps) => {
   const {
+    backLinkText,
     pageHeading,
     templateNameHeading,
     templateIdHeading,
@@ -21,7 +22,7 @@ export const TemplateSubmitted = ({
     liveHeading,
     liveLinkText,
     liveText,
-  } = templateSubmittedPageContent;
+  } = content.components.templateSubmitted;
 
   return (
     <NHSNotifyMain>
@@ -61,7 +62,7 @@ export const TemplateSubmitted = ({
           <hr className='nhsuk-section-break--visible' />
           <p>
             <Link id='go-back-link' href='/manage-templates'>
-              {templateSubmittedPageContent.backLinkText}
+              {backLinkText}
             </Link>
           </p>
         </div>

--- a/frontend/src/components/molecules/ViewEmailTemplate/ViewEmailTemplate.tsx
+++ b/frontend/src/components/molecules/ViewEmailTemplate/ViewEmailTemplate.tsx
@@ -8,7 +8,7 @@ import {
 import { getBasePath } from '@utils/get-base-path';
 import { renderEmailMarkdown } from '@utils/markdownit';
 import { BackLink } from 'nhsuk-react-components';
-import { viewSubmittedTemplatePageContent as content } from '@content/content';
+import content from '@content/content';
 import Link from 'next/link';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
 
@@ -19,6 +19,9 @@ export function ViewEmailTemplate({
   const templateMessage = initialState.message;
 
   const html = renderEmailMarkdown(templateMessage);
+
+  const { cannotEdit, createNewTemplate } =
+    content.components.viewSubmittedTemplate;
 
   return (
     <>
@@ -33,8 +36,8 @@ export function ViewEmailTemplate({
               subject={templateSubjectLine}
               message={html}
             />
-            <p>{content.cannotEdit}</p>
-            <p>{content.createNewTemplate}</p>
+            <p>{cannotEdit}</p>
+            <p>{createNewTemplate}</p>
             <p>
               <Link href='/manage-templates'>Back to all templates</Link>
             </p>

--- a/frontend/src/components/molecules/ViewNHSAppTemplate/ViewNHSAppTemplate.tsx
+++ b/frontend/src/components/molecules/ViewNHSAppTemplate/ViewNHSAppTemplate.tsx
@@ -8,7 +8,7 @@ import {
 import { getBasePath } from '@utils/get-base-path';
 import { renderNHSAppMarkdown } from '@utils/markdownit';
 import { BackLink } from 'nhsuk-react-components';
-import { viewSubmittedTemplatePageContent as content } from '@content/content';
+import content from '@content/content';
 import Link from 'next/link';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
 
@@ -19,6 +19,9 @@ export function ViewNHSAppTemplate({
 
   const html = renderNHSAppMarkdown(templateMessage);
 
+  const { cannotEdit, createNewTemplate } =
+    content.components.viewSubmittedTemplate;
+
   return (
     <>
       <BackLink href={`${getBasePath()}/manage-templates`}>
@@ -28,8 +31,8 @@ export function ViewNHSAppTemplate({
         <div className='nhsuk-grid-row'>
           <div className='nhsuk-grid-column-full'>
             <PreviewTemplate.NHSApp template={initialState} message={html} />
-            <p>{content.cannotEdit}</p>
-            <p>{content.createNewTemplate}</p>
+            <p>{cannotEdit}</p>
+            <p>{createNewTemplate}</p>
             <p>
               <Link href='/manage-templates'>Back to all templates</Link>
             </p>

--- a/frontend/src/components/molecules/ViewSMSTemplate/ViewSMSTemplate.tsx
+++ b/frontend/src/components/molecules/ViewSMSTemplate/ViewSMSTemplate.tsx
@@ -8,7 +8,7 @@ import {
 import { getBasePath } from '@utils/get-base-path';
 import { renderSMSMarkdown } from '@utils/markdownit';
 import { BackLink } from 'nhsuk-react-components';
-import { viewSubmittedTemplatePageContent as content } from '@content/content';
+import content from '@content/content';
 import Link from 'next/link';
 import { NHSNotifyMain } from '@atoms/NHSNotifyMain/NHSNotifyMain';
 
@@ -19,6 +19,9 @@ export function ViewSMSTemplate({
 
   const html = renderSMSMarkdown(templateMessage);
 
+  const { cannotEdit, createNewTemplate } =
+    content.components.viewSubmittedTemplate;
+
   return (
     <>
       <BackLink href={`${getBasePath()}/manage-templates`}>
@@ -28,8 +31,8 @@ export function ViewSMSTemplate({
         <div className='nhsuk-grid-row'>
           <div className='nhsuk-grid-column-full'>
             <PreviewTemplate.Sms template={initialState} message={html} />
-            <p>{content.cannotEdit}</p>
-            <p>{content.createNewTemplate}</p>
+            <p>{cannotEdit}</p>
+            <p>{createNewTemplate}</p>
             <p>
               <Link href='/manage-templates'>Back to all templates</Link>
             </p>

--- a/frontend/src/content/content.ts
+++ b/frontend/src/content/content.ts
@@ -393,8 +393,8 @@ export const channelGuidanceContent = {
   },
 };
 
-export const createNhsAppTemplatePageContent = {
-  pageHeading: 'Create NHS App message template',
+const templateFormNhsAppContent = {
+  pageHeadingSuffix: 'NHS App message template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
   templateMessageLabelText: 'Message',
@@ -404,8 +404,8 @@ export const createNhsAppTemplatePageContent = {
   backLinkText: 'Back to choose a template type',
 };
 
-export const createEmailTemplatePageContent = {
-  pageHeading: 'Create email template',
+const templateFormEmailContent = {
+  pageHeadingSuffix: 'email template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
   templateSubjectLineLabelText: 'Subject line',
@@ -415,22 +415,8 @@ export const createEmailTemplatePageContent = {
   backLinkText: 'Back to choose a template type',
 };
 
-export const templateSubmittedPageContent = {
-  pageHeading: 'Template submitted',
-  templateNameHeading: 'Template name',
-  templateIdHeading: 'Template ID',
-  doNextHeading: 'What you need to do next',
-  notLiveHeading: "If you're currently onboarding",
-  notLiveText:
-    "Tell your onboarding manager once you've submitted all your templates.",
-  liveHeading: "If you've already onboarded",
-  liveText: "Once you've submitted all your templates",
-  liveLinkText: 'raise a request with the service desk (opens in a new tab).',
-  backLinkText: 'Back to all templates',
-};
-
-export const createSmsTemplatePageContent = {
-  pageHeading: 'Create text message template',
+const templateFormSmsContent = {
+  pageHeadingSuffix: 'text message template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
   templateMessageLabelText: 'Message',
@@ -442,6 +428,20 @@ export const createSmsTemplatePageContent = {
     'Learn more about character counts and text messaging pricing (opens in a new tab)',
   buttonText: 'Save and preview',
   backLinkText: 'Back to choose a template type',
+};
+
+const templateSubmittedPageContent = {
+  pageHeading: 'Template submitted',
+  templateNameHeading: 'Template name',
+  templateIdHeading: 'Template ID',
+  doNextHeading: 'What you need to do next',
+  notLiveHeading: "If you're currently onboarding",
+  notLiveText:
+    "Tell your onboarding manager once you've submitted all your templates.",
+  liveHeading: "If you've already onboarded",
+  liveText: "Once you've submitted all your templates",
+  liveLinkText: 'raise a request with the service desk (opens in a new tab).',
+  backLinkText: 'Back to all templates',
 };
 
 export const viewSubmittedTemplatePageContent = {
@@ -476,6 +476,9 @@ const content = {
     reviewSMSTemplateContent,
     messageFormattingComponent,
     logoutWarningComponent,
+    templateFormEmailContent,
+    templateFormNhsAppContent,
+    templateFormSmsContent,
   },
   pages: {
     homePage,

--- a/frontend/src/content/content.ts
+++ b/frontend/src/content/content.ts
@@ -1,7 +1,7 @@
 import { getBasePath } from '@utils/get-base-path';
 import { TemplateType } from 'nhs-notify-web-template-management-utils';
 
-const headerComponent = {
+const header = {
   serviceName: 'Notify',
   links: {
     signIn: {
@@ -17,7 +17,7 @@ const headerComponent = {
   },
 };
 
-const footerComponent = {
+const footer = {
   nhsEngland: 'NHS England',
   supportLinks: 'Support links',
   links: {
@@ -32,7 +32,7 @@ const footerComponent = {
   },
 };
 
-const personalisationComponent = {
+const personalisation = {
   header: 'Personalisation',
   details: {
     title: 'Personalisation fields',
@@ -60,7 +60,7 @@ const personalisationComponent = {
   },
 };
 
-const messageFormattingComponent = {
+const messageFormatting = {
   header: 'Message formatting',
   lineBreaksAndParagraphs: {
     title: 'Line breaks and paragraphs',
@@ -201,7 +201,7 @@ const manageTemplates = {
   },
 };
 
-const reviewEmailTemplateContent = {
+const reviewEmailTemplate = {
   sectionHeading: 'Template saved',
   form: {
     errorHeading: 'There is a problem',
@@ -214,7 +214,7 @@ const reviewEmailTemplateContent = {
   },
 };
 
-const reviewNHSAppTemplateContent = {
+const reviewNHSAppTemplate = {
   sectionHeading: 'Template saved',
   form: {
     errorHeading: 'There is a problem',
@@ -227,7 +227,7 @@ const reviewNHSAppTemplateContent = {
   },
 };
 
-const reviewSMSTemplateContent = {
+const reviewSMSTemplate = {
   sectionHeading: 'Template saved',
   details: {
     heading: 'Who your text message will be sent from',
@@ -253,7 +253,7 @@ const reviewSMSTemplateContent = {
   },
 };
 
-const error404PageContent = {
+const error404 = {
   pageHeading: 'Sorry, we could not find that page',
   p1: 'You may have typed or pasted a web address incorrectly. ',
   backLink: {
@@ -268,7 +268,7 @@ const error404PageContent = {
   },
 };
 
-export const submitTemplateContent = {
+const submitTemplate = {
   pageHeading: 'Submit',
   warningCalloutLabel: 'Important',
   warningCalloutText:
@@ -288,7 +288,7 @@ export const submitTemplateContent = {
   buttonText: 'Submit template',
 };
 
-export const copyTemplatePageContent = {
+const copyTemplate = {
   pageHeading: 'Copy',
   radiosLabel: 'Choose a template type',
   errorHeading: 'There is a problem',
@@ -297,7 +297,7 @@ export const copyTemplatePageContent = {
   backLinkText: 'Back to all templates',
 };
 
-export const chooseTemplatePageContent = {
+const chooseTemplate = {
   pageHeading: 'Choose a template type to create',
   errorHeading: 'There is a problem',
   buttonText: 'Continue',
@@ -307,7 +307,7 @@ export const chooseTemplatePageContent = {
   backLinkText: 'Back to all templates',
 };
 
-export const nameYourTemplateContent = {
+const nameYourTemplate = {
   templateNameDetailsSummary: 'Naming your templates',
   templateNameDetailsOpeningParagraph:
     'You should name your templates in a way that works best for your service or organisation.',
@@ -335,7 +335,7 @@ export const nameYourTemplateContent = {
   },
 };
 
-export const channelGuidanceContent = {
+const channelGuidance = {
   [TemplateType.NHS_APP]: {
     heading: 'More about NHS App messages',
     guidanceLinks: [
@@ -393,7 +393,7 @@ export const channelGuidanceContent = {
   },
 };
 
-const templateFormNhsAppContent = {
+const templateFormNhsApp = {
   pageHeadingSuffix: 'NHS App message template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
@@ -404,7 +404,7 @@ const templateFormNhsAppContent = {
   backLinkText: 'Back to choose a template type',
 };
 
-const templateFormEmailContent = {
+const templateFormEmail = {
   pageHeadingSuffix: 'email template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
@@ -415,7 +415,7 @@ const templateFormEmailContent = {
   backLinkText: 'Back to choose a template type',
 };
 
-const templateFormSmsContent = {
+const templateFormSms = {
   pageHeadingSuffix: 'text message template',
   errorHeading: 'There is a problem',
   templateNameLabelText: 'Template name',
@@ -430,7 +430,7 @@ const templateFormSmsContent = {
   backLinkText: 'Back to choose a template type',
 };
 
-const templateSubmittedPageContent = {
+const templateSubmitted = {
   pageHeading: 'Template submitted',
   templateNameHeading: 'Template name',
   templateIdHeading: 'Template ID',
@@ -444,20 +444,20 @@ const templateSubmittedPageContent = {
   backLinkText: 'Back to all templates',
 };
 
-export const viewSubmittedTemplatePageContent = {
+const viewSubmittedTemplate = {
   cannotEdit: 'This template cannot be edited because it has been submitted.',
   createNewTemplate:
     'If you want to change a submitted or live template, you must create a new template to replace it.',
 };
 
-export const deleteTemplatePageContent = {
+const deleteTemplate = {
   pageHeading: 'Are you sure you want to delete the template',
   hintText: "The template will be removed and you won't be able to recover it.",
   noButtonText: 'No, go back',
   yesButtonText: 'Yes, delete template',
 };
 
-const logoutWarningComponent = {
+const logoutWarning = {
   heading: "For security reasons, you'll be signed out in",
   signIn: 'Stay signed in',
   body: "If you're signed out, any unsaved changes will be lost.",
@@ -468,21 +468,29 @@ const content = {
     mainLayout,
   },
   components: {
-    headerComponent,
-    footerComponent,
-    personalisationComponent,
-    reviewEmailTemplateContent,
-    reviewNHSAppTemplateContent,
-    reviewSMSTemplateContent,
-    messageFormattingComponent,
-    logoutWarningComponent,
-    templateFormEmailContent,
-    templateFormNhsAppContent,
-    templateFormSmsContent,
+    channelGuidance,
+    chooseTemplate,
+    copyTemplate,
+    deleteTemplate,
+    footer,
+    header,
+    logoutWarning,
+    messageFormatting,
+    nameYourTemplate,
+    personalisation,
+    reviewEmailTemplate,
+    reviewNHSAppTemplate,
+    reviewSMSTemplate,
+    submitTemplate,
+    templateFormEmail,
+    templateFormNhsApp,
+    templateFormSms,
+    templateSubmitted,
+    viewSubmittedTemplate,
   },
   pages: {
     homePage,
-    error404PageContent,
+    error404,
     manageTemplates,
   },
 };

--- a/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/email/template-mgmt-edit-email-page.component.spec.ts
@@ -72,7 +72,7 @@ test.describe('Edit Email message template Page', () => {
     );
 
     await expect(editEmailTemplatePage.pageHeader).toHaveText(
-      'Create email template'
+      'Edit email template'
     );
   });
 

--- a/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/nhs-app/template-mgmt-edit-nhs-app-template-page.component.spec.ts
@@ -58,7 +58,7 @@ test.describe('Edit NHS App Template Page', () => {
       `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
     );
     await expect(editTemplatePage.pageHeader).toHaveText(
-      'Create NHS App message template'
+      'Edit NHS App message template'
     );
   });
 
@@ -88,7 +88,7 @@ test.describe('Edit NHS App Template Page', () => {
       `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
     );
     await expect(editTemplatePage.pageHeader).toHaveText(
-      'Create NHS App message template'
+      'Edit NHS App message template'
     );
     await editTemplatePage.clickSaveAndPreviewButton();
     await expect(page.locator('.nhsuk-error-summary')).toBeVisible();
@@ -132,7 +132,7 @@ test.describe('Edit NHS App Template Page', () => {
       `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
     );
     await expect(editTemplatePage.pageHeader).toHaveText(
-      'Create NHS App message template'
+      'Edit NHS App message template'
     );
     const templateName = 'NHS Testing 123';
     await page.locator('[id="nhsAppTemplateName"]').fill(templateName);
@@ -155,7 +155,7 @@ test.describe('Edit NHS App Template Page', () => {
       `${baseURL}/templates/edit-nhs-app-template/${templates.emptyTemplateData.id}`
     );
     await expect(editTemplatePage.pageHeader).toHaveText(
-      'Create NHS App message template'
+      'Edit NHS App message template'
     );
     const templateMessage = 'Test Message box';
     await page.locator('[id="nhsAppTemplateMessage"]').fill(templateMessage);

--- a/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/sms/template-mgmt-edit-sms-page.component.spec.ts
@@ -68,7 +68,7 @@ test.describe('Edit SMS message template Page', () => {
     );
 
     await expect(editSmsTemplatePage.pageHeader).toHaveText(
-      'Create text message template'
+      'Edit text message template'
     );
 
     await expect(editSmsTemplatePage.pricingLink).toHaveAttribute(


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Conditionally renders a heading starting 'Edit' or 'Create' depending on whether the template form component is in edit mode or not.

Removes the borders around the email template form: https://nhsd-jira.digital.nhs.uk/browse/CCM-8495

`content.ts` was using a mix of default and named exports. I have aligned everything to the default export and removed redundant and misleading name segments such as 'Page', 'Content', 'Component' etc.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
