### PR TITLE
CCM-9648-sandbox resource naming

### DIFF
--- a/infrastructure/terraform/components/app/module_backend_api.tf
+++ b/infrastructure/terraform/components/app/module_backend_api.tf
@@ -4,6 +4,7 @@ module "backend_api" {
   source = "../../modules/backend-api"
 
   project               = var.project
+  component             = "${var.component}-api"
   environment           = var.environment
   aws_account_id        = var.aws_account_id
   region                = var.region

--- a/infrastructure/terraform/components/sandbox/README.md
+++ b/infrastructure/terraform/components/sandbox/README.md
@@ -10,7 +10,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS Account ID (numeric) | `string` | n/a | yes |
-| <a name="input_component"></a> [component](#input\_component) | The variable encapsulating the name of this component | `string` | `"sandbox"` | no |
+| <a name="input_component"></a> [component](#input\_component) | The variable encapsulating the name of this component | `string` | `"sbx"` | no |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of default tags to apply to all taggable resources within the component | `map(string)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | The group variables are being inherited from (often synonymous with account short-name) | `string` | n/a | yes |

--- a/infrastructure/terraform/components/sandbox/module_backend_api.tf
+++ b/infrastructure/terraform/components/sandbox/module_backend_api.tf
@@ -2,6 +2,7 @@ module "backend_api" {
   source = "../../modules/backend-api"
 
   project               = var.project
+  component             = "${var.component}-api"
   environment           = var.environment
   aws_account_id        = var.aws_account_id
   region                = var.region

--- a/infrastructure/terraform/components/sandbox/variables.tf
+++ b/infrastructure/terraform/components/sandbox/variables.tf
@@ -38,7 +38,7 @@ variable "group" {
 variable "component" {
   type        = string
   description = "The variable encapsulating the name of this component"
-  default     = "sandbox"
+  default     = "sbx"
 }
 
 variable "default_tags" {

--- a/infrastructure/terraform/modules/backend-api/README.md
+++ b/infrastructure/terraform/modules/backend-api/README.md
@@ -11,7 +11,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS Account ID (numeric) | `string` | n/a | yes |
 | <a name="input_cognito_config"></a> [cognito\_config](#input\_cognito\_config) | Cognito config | <pre>object({<br/>    USER_POOL_ID : string,<br/>    USER_POOL_CLIENT_ID : string<br/>  })</pre> | n/a | yes |
-| <a name="input_component"></a> [component](#input\_component) | The variable encapsulating the name of this component | `string` | `"api"` | no |
+| <a name="input_component"></a> [component](#input\_component) | The variable encapsulating the name of this component | `string` | n/a | yes |
 | <a name="input_csi"></a> [csi](#input\_csi) | CSI from the parent component | `string` | n/a | yes |
 | <a name="input_dynamodb_kms_key_arn"></a> [dynamodb\_kms\_key\_arn](#input\_dynamodb\_kms\_key\_arn) | KMS Key ARN for encrypting DynamoDB data. If not given, a key will be created. | `string` | `""` | no |
 | <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Enable Backups for the DynamoDB table? | `bool` | `true` | no |

--- a/infrastructure/terraform/modules/backend-api/locals.tf
+++ b/infrastructure/terraform/modules/backend-api/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  csi = "${var.csi}-${var.component}"
+  csi = "${var.project}-${var.environment}-${var.component}"
 
   lambdas_source_code_dir = abspath("${path.module}/../../../../lambdas")
 

--- a/infrastructure/terraform/modules/backend-api/variables.tf
+++ b/infrastructure/terraform/modules/backend-api/variables.tf
@@ -35,7 +35,6 @@ variable "group" {
 variable "component" {
   type        = string
   description = "The variable encapsulating the name of this component"
-  default     = "api"
 }
 
 ##


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Makes 'component' equal to `sbx-api` or `app-api` within the backend-api module. This resolves the problem that resources created via a shared module use the 'component' local directly, rather than using the local CSI (which already references sandbox/app) and therefore clash with each other.

Plan run against main: https://github.com/NHSDigital/nhs-notify-internal/actions/runs/14356510524/job/40247100617
The 'internal' and 'quarantine' buckets are re-created, but these are flagged letters infrastructure.
 
## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
