### PR TITLE
CCM-9691 Fix amplify branch name

### DIFF
--- a/infrastructure/terraform/components/branch/locals.tf
+++ b/infrastructure/terraform/components/branch/locals.tf
@@ -1,4 +1,4 @@
 locals {
   root_domain_name       = "${var.environment}.${local.app.amplify["domain_name"]}"
-  normalised_branch_name = lower(substr(join("", regexall("[a-zA-Z0-9-]+", var.branch_name)), 0, 25))
+  normalised_branch_name = trimsuffix(lower(substr(join("", regexall("[a-zA-Z0-9-]+", var.branch_name)), 0, 25)),"-")
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Trims trailing hyphens from amplify branch names to avoid error in pipeline

Failing run (before change):
https://github.com/NHSDigital/nhs-notify-internal/actions/runs/14467691207/job/40573865919
Passing run (after change):
https://github.com/NHSDigital/nhs-notify-internal/actions/runs/14467764585/job/40574173310

## Context

- Fixes the issue where deploy pipeline would fail for branch names containing '-' at the 26th character

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
