### PR TITLE
CCM-9234: add ec2 revoke permission to Github_Deploy role

### DIFF
--- a/infrastructure/terraform/components/acct/iam_policy_github_deploy_overload.tf
+++ b/infrastructure/terraform/components/acct/iam_policy_github_deploy_overload.tf
@@ -48,6 +48,7 @@ data "aws_iam_policy_document" "github_deploy" {
       "ec2:ModifyVpc*",
       "ec2:ReleaseAddress",
       "ec2:Replace*",
+      "ec2:Revoke*",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- adds  ec2 revoke permissions to Github_Deploy role. 

Deployment error happening on this [pipeline](https://github.com/NHSDigital/nhs-notify-internal/actions/runs/14489956781/job/40643976500#step:4:302).

Error:
`not authorized to perform: ec2:RevokeSecurityGroupEgress`

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
