### PR TITLE
CCM-9344: remove test team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,6 @@
 /.github/                   @NHSDigital/nhs-notify-web-template-management-admins
 *.code-workspace            @NHSDigital/nhs-notify-web-template-management-admins
 /docs/                      @NHSDigital/nhs-notify-web-template-management
-/docs/testing/              @NHSDigital/nhs-notify-web-template-management-testers
-/tests/test-team/           @NHSDigital/nhs-notify-web-template-management-testers
 /infrastructure/terraform/  @NHSDigital/nhs-notify-platform
 
 # Codeowners must be final check


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

remove the nhs-notify-web-template-management-testers group from being a compulsory reviewer on the repo as this is no longer a step in the QA process

## Context

The QA process has been changed to no longer include a code review by a member of the testing team on the nhs-notify-web-template-management repo code changes

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
