### PR TITLE
CCM-9857: app pre sh broken

### DIFF
--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,5 +1,5 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
-
-./layers/pdfjs/build.sh
+find ./lambdas -maxdepth 3
+./lambdas/layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,5 +1,5 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
-find ./lambdas -maxdepth 3
+find . -maxdepth 3
 ./lambdas/layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,8 +1,4 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
-ls -la ./lambdas
-ls -la "lambdas/layers/"
-
-ls -la "lambdas/layers/pdfjs/" 2>/dev/null || echo "pdfjs directory not found"
-./lambdas/layers/pdfjs/build.sh
+$(git rev-parse --show-toplevel)/lambdas/layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,4 +1,5 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
+
 $(git rev-parse --show-toplevel)/lambdas/layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,5 +1,7 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
-find . -maxdepth 3
+ls -la "lambdas/layers/"
+
+ls -la "lambdas/layers/pdfjs/" 2>/dev/null || echo "pdfjs directory not found"
 ./lambdas/layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -2,4 +2,4 @@ npm ci
 
 npm run generate-dependencies --workspaces --if-present
 
-./lambdas/layers/pdfjs/build.sh
+./layers/pdfjs/build.sh

--- a/infrastructure/terraform/components/app/pre.sh
+++ b/infrastructure/terraform/components/app/pre.sh
@@ -1,6 +1,7 @@
 npm ci
 
 npm run generate-dependencies --workspaces --if-present
+ls -la ./lambdas
 ls -la "lambdas/layers/"
 
 ls -la "lambdas/layers/pdfjs/" 2>/dev/null || echo "pdfjs directory not found"

--- a/infrastructure/terraform/modules/backend-api/lambda_layer_pdfjs.tf
+++ b/infrastructure/terraform/modules/backend-api/lambda_layer_pdfjs.tf
@@ -2,6 +2,5 @@ resource "aws_lambda_layer_version" "lambda_layer_pdfjs" {
   layer_name          = "${local.csi}-nodejs20-pdfjs-dist"
   description         = "pdfjs-dist dependencies for Node.js v20"
   filename            = local.pdfjs_layer_zip
-  source_code_hash    = filebase64sha256(local.pdfjs_layer_zip)
   compatible_runtimes = ["nodejs20.x"]
 }

--- a/lambdas/layers/pdfjs/build.sh
+++ b/lambdas/layers/pdfjs/build.sh
@@ -14,7 +14,7 @@ npm install --force
 cp -r node_modules/* dist/layer/nodejs/node_modules
 
 cd dist/layer
-zip -r pdfjs-layer.zip nodejs
+zip -Xr pdfjs-layer.zip nodejs
 
 echo
 echo "PDF.js Lambda Layer packaging done"

--- a/lambdas/layers/pdfjs/build.sh
+++ b/lambdas/layers/pdfjs/build.sh
@@ -14,7 +14,7 @@ npm install --force
 cp -r node_modules/* dist/layer/nodejs/node_modules
 
 cd dist/layer
-zip -Xr pdfjs-layer.zip nodejs
+zip -r pdfjs-layer.zip nodejs
 
 echo
 echo "PDF.js Lambda Layer packaging done"

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,7 +195,6 @@
         "date-fns": "^4.1.0",
         "ksuid": "^3.0.0",
         "nhs-notify-entity-update-command-builder": "*",
-        "nhs-notify-web-template-management-test-helper-utils": "*",
         "nhs-notify-web-template-management-utils": "*",
         "node-cache": "^5.1.2",
         "ssh2-sftp-client": "^9.1.0",
@@ -213,6 +212,7 @@
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.7",
+        "nhs-notify-web-template-management-test-helper-utils": "*",
         "ts-jest": "^29.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.2"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The relative path to `lambdas/layers/pdfjs/build.sh` doesn't work in the context in which `pre.sh` is run

`pre.sh: line 5: ./lambdas/layers/pdfjs/build.sh: No such file or directory`

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
