### PR TITLE
CCM-9923: add download bucket assertion to letter e2e test

### DIFF
--- a/tests/test-team/template-mgmt-e2e-tests/template-mgmt-letter-full.e2e.spec.ts
+++ b/tests/test-team/template-mgmt-e2e-tests/template-mgmt-letter-full.e2e.spec.ts
@@ -181,19 +181,26 @@ test.describe('letter complete e2e journey', () => {
       );
 
       expect(pdfHrefs.length).toBeGreaterThan(0);
-      for (const href of pdfHrefs) expect(href).toContain(templateId);
 
       const downloadBucketMetadata = await Promise.all(
         pdfHrefs.map((href) => {
-          const [downloadBucketPath] =
+          const [, downloadBucketPath] =
             (href as string).match(
-              // eslint-disable-next-line security/detect-unsafe-regex, sonarjs/slow-regex
-              /((?:[^/]+\/){3}[^/]+)\/?$/
+              // eslint-disable-next-line security/detect-non-literal-regexp
+              new RegExp(
+                `/templates/files/(${user.userId}/proofs/${templateId}/[^/]+)/?$`
+              )
             ) ?? [];
+
+          if (!downloadBucketPath) {
+            throw new Error(
+              `Could not determine bucket path based on URL: ${href}`
+            );
+          }
 
           return templateStorageHelper.getS3Metadata(
             process.env.TEMPLATES_DOWNLOAD_BUCKET_NAME,
-            downloadBucketPath!
+            downloadBucketPath
           );
         })
       );


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The ACs on this ticket were already complete, apart from checking that download links correspond to an object in the download bucket

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
