### PR TITLE
[CCM-11410] Fix letter template guidance URL

### DIFF
--- a/frontend/src/__tests__/components/forms/LetterTemplateForm.test.tsx/__snapshots__/LetterTemplateForm.test.tsx.snap
+++ b/frontend/src/__tests__/components/forms/LetterTemplateForm.test.tsx/__snapshots__/LetterTemplateForm.test.tsx.snap
@@ -395,7 +395,7 @@ exports[`Client-side validation triggers 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -832,7 +832,7 @@ exports[`hides right-to-left language warning when language changes 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -1316,7 +1316,7 @@ exports[`renders page one error 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -1816,7 +1816,7 @@ exports[`renders page with multiple errors 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -2289,7 +2289,7 @@ exports[`renders page with preloaded field values 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -2742,7 +2742,7 @@ exports[`shows right-to-left language warning when language changes 1`] = `
             <p>
               <a
                 data-testid="pdf-guidance-link"
-                href="/using-nhs-notify/letter-templates"
+                href="/using-nhs-notify/upload-a-letter"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/frontend/src/content/content.ts
+++ b/frontend/src/content/content.ts
@@ -554,7 +554,7 @@ const templateFormLetter = {
   templatePdfLabelText: 'Letter template PDF',
   templatePdfHintText:
     'Your letter must follow our letter specification and be no bigger than 5MB',
-  templatePdfGuidanceLink: '/using-nhs-notify/letter-templates',
+  templatePdfGuidanceLink: '/using-nhs-notify/upload-a-letter',
   templatePdfGuidanceLinkText:
     'Learn how to create letter templates to our specification (opens in a new tab)',
   templateCsvLabelText: 'Example personalisation CSV (optional)',

--- a/tests/test-team/template-mgmt-component-tests/letter/template-mgmt-create-letter-template-page.component.spec.ts
+++ b/tests/test-team/template-mgmt-component-tests/letter/template-mgmt-create-letter-template-page.component.spec.ts
@@ -142,7 +142,7 @@ test.describe('Create Letter Template Page', () => {
   const moreInfoLinks = [
     {
       name: 'Learn how to create letter templates to our specification (opens in a new tab)',
-      url: 'using-nhs-notify/letter-templates',
+      url: 'using-nhs-notify/upload-a-letter',
     },
     {
       name: 'Learn how to provide example personalisation data (opens in a new tab)',


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Updates URL used for letter template guidance to correct URL
- Updates unit tests and e2e tests

<img width="1580" height="254" alt="image" src="https://github.com/user-attachments/assets/269ef68a-052c-4b6f-905c-738b19e98e75" />

## Context

- "Learn how to create letter templates to our specification (opens in a new tab)" points to a page that no longer exists

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
